### PR TITLE
Ajout d'une permission avancée pour consulter les prix d'achat

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,7 @@ For users:
 ----------
 
 
+* NEW: Ajout de la permission "Consulter les prix d'achat" pour permettre la consultation des prix fournisseurs sans droit de création.
 
 For developers:
 ---------------

--- a/htdocs/core/lib/product.lib.php
+++ b/htdocs/core/lib/product.lib.php
@@ -43,13 +43,14 @@ function product_prepare_head($object)
 	$langs->load("products");
 
 	$label = $langs->trans('Product');
-	$usercancreadprice = getDolGlobalString('MAIN_USE_ADVANCED_PERMS') ? $user->hasRight('product', 'product_advance', 'read_prices') : $user->hasRight('product', 'read');
-	$usercancreadsupplierprice = getDolGlobalString('MAIN_USE_ADVANCED_PERMS') ? $user->hasRight('product', 'product_advance', 'read_supplier_prices') : $user->hasRight('product', 'read');
+        $usercancreadprice = getDolGlobalString('MAIN_USE_ADVANCED_PERMS') ? $user->hasRight('product', 'product_advance', 'read_prices') : $user->hasRight('product', 'read');
+        // Allow supplier price consultation with dedicated permission when advanced rights are enabled / Permet la consultation des prix fournisseurs avec la permission dédiée lorsque les droits avancés sont activés
+        $usercancreadsupplierprice = getDolGlobalString('MAIN_USE_ADVANCED_PERMS') ? ($user->hasRight('product', 'product_advance', 'read_supplier_prices') || $user->hasRight('product', 'product_advance', 'consult_supplier_prices')) : $user->hasRight('product', 'read');
 
 	if ($object->isService()) {
 		$label = $langs->trans('Service');
-		$usercancreadprice = getDolGlobalString('MAIN_USE_ADVANCED_PERMS') ? $user->hasRight('service', 'service_advance', 'read_prices') : $user->hasRight('service', 'read');
-		$usercancreadsupplierprice = getDolGlobalString('MAIN_USE_ADVANCED_PERMS') ? $user->hasRight('service', 'service_advance', 'read_supplier_prices') : $user->hasRight('service', 'read');
+                $usercancreadprice = getDolGlobalString('MAIN_USE_ADVANCED_PERMS') ? $user->hasRight('service', 'service_advance', 'read_prices') : $user->hasRight('service', 'read');
+                $usercancreadsupplierprice = getDolGlobalString('MAIN_USE_ADVANCED_PERMS') ? ($user->hasRight('service', 'service_advance', 'read_supplier_prices') || $user->hasRight('service', 'service_advance', 'consult_supplier_prices')) : $user->hasRight('service', 'read');
 	}
 
 	$h = 0;

--- a/htdocs/core/modules/modProduct.class.php
+++ b/htdocs/core/modules/modProduct.class.php
@@ -138,13 +138,22 @@ class modProduct extends DolibarrModules
 		$this->rights[$r][5] = 'read_prices';
 		$r++;
 
-		$this->rights[$r][0] = 35; // id de la permission
-		$this->rights[$r][1] = 'Read supplier prices'; // libelle de la permission
-		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
-		$this->rights[$r][4] = 'product_advance';
-		$this->rights[$r][5] = 'read_supplier_prices';
-		$r++;
+                $this->rights[$r][0] = 35; // id de la permission
+                $this->rights[$r][1] = 'Read supplier prices'; // libelle de la permission
+                $this->rights[$r][2] = 'w'; // type de la permission (deprecated)
+                $this->rights[$r][3] = 0; // La permission est-elle une permission par default
+                $this->rights[$r][4] = 'product_advance';
+                $this->rights[$r][5] = 'read_supplier_prices';
+                $r++;
+
+                // Allow consulting supplier buying prices when advanced rights are enabled / Permet de consulter les prix d'achat fournisseurs quand les droits avancés sont activés
+                $this->rights[$r][0] = 36; // id de la permission
+                $this->rights[$r][1] = 'PermissionConsultSupplierBuyingPrices'; // libelle de la permission
+                $this->rights[$r][2] = 'r'; // type de la permission (deprecated)
+                $this->rights[$r][3] = 0; // La permission est-elle une permission par default
+                $this->rights[$r][4] = 'product_advance';
+                $this->rights[$r][5] = 'consult_supplier_prices';
+                $r++;
 
 		$this->rights[$r][0] = 34; // id de la permission
 		$this->rights[$r][1] = 'Delete products'; // libelle de la permission

--- a/htdocs/langs/en_US/products.lang
+++ b/htdocs/langs/en_US/products.lang
@@ -170,6 +170,7 @@ ProductIsUsed=This product is used
 NewRefForClone=Ref. of new product/service
 SellingPrices=Selling prices
 BuyingPrices=Buying prices
+PermissionConsultSupplierBuyingPrices=View supplier buying prices
 CustomerPrices=Customer prices
 SuppliersPrices=Vendor prices
 SuppliersPricesOfProductsOrServices=Vendor prices (of products or services)

--- a/htdocs/langs/fr_FR/products.lang
+++ b/htdocs/langs/fr_FR/products.lang
@@ -175,6 +175,7 @@ ProductIsUsed=Ce produit est utilisé
 NewRefForClone=Réf. du nouveau produit/service
 SellingPrices=Prix de vente
 BuyingPrices=Prix d'achat
+PermissionConsultSupplierBuyingPrices=Consulter les prix d'achat
 CustomerPrices=Prix clients
 SuppliersPrices=Prix fournisseurs
 SuppliersPricesOfProductsOrServices=Prix fournisseurs (des produits ou services)

--- a/htdocs/product/price_suppliers.php
+++ b/htdocs/product/price_suppliers.php
@@ -121,16 +121,37 @@ if ($id > 0 || $ref) {
 
 $usercanread = (($object->type == Product::TYPE_PRODUCT && $user->hasRight('produit', 'lire')) || ($object->type == Product::TYPE_SERVICE && $user->hasRight('service', 'lire')));
 $usercancreate = (($object->type == Product::TYPE_PRODUCT && $user->hasRight('produit', 'creer')) || ($object->type == Product::TYPE_SERVICE && $user->hasRight('service', 'creer')));
+// Allow supplier price consultation right without creation capability / Permet la consultation des prix fournisseurs sans droit de création
+$usercanconsultsuppliers = (bool) $usercancreate;
+if ($prod->id > 0) {
+        if ($prod->type == Product::TYPE_PRODUCT) {
+                if (getDolGlobalString('MAIN_USE_ADVANCED_PERMS')) {
+                        $usercanconsultsuppliers = $usercanconsultsuppliers || $user->hasRight('product', 'product_advance', 'read_supplier_prices') || $user->hasRight('product', 'product_advance', 'consult_supplier_prices');
+                } else {
+                        $usercanconsultsuppliers = $usercanconsultsuppliers || $user->hasRight('produit', 'lire');
+                }
+        } elseif ($prod->type == Product::TYPE_SERVICE) {
+                if (getDolGlobalString('MAIN_USE_ADVANCED_PERMS')) {
+                        $usercanconsultsuppliers = $usercanconsultsuppliers || $user->hasRight('service', 'service_advance', 'read_supplier_prices') || $user->hasRight('service', 'service_advance', 'consult_supplier_prices');
+                } else {
+                        $usercanconsultsuppliers = $usercanconsultsuppliers || $user->hasRight('service', 'lire');
+                }
+        }
+}
 
 if ($object->id > 0) {
-	if ($object->type == $object::TYPE_PRODUCT) {
-		restrictedArea($user, 'produit', $object->id, 'product&product', '', '');
-	}
-	if ($object->type == $object::TYPE_SERVICE) {
-		restrictedArea($user, 'service', $object->id, 'product&product', '', '');
-	}
+        if ($object->type == $object::TYPE_PRODUCT) {
+                restrictedArea($user, 'produit', $object->id, 'product&product', '', '');
+        }
+        if ($object->type == $object::TYPE_SERVICE) {
+                restrictedArea($user, 'service', $object->id, 'product&product', '', '');
+        }
 } else {
-	restrictedArea($user, 'produit|service', $fieldvalue, 'product&product', '', '', $fieldtype);
+        restrictedArea($user, 'produit|service', $fieldvalue, 'product&product', '', '', $fieldtype);
+}
+
+if (getDolGlobalString('MAIN_USE_ADVANCED_PERMS') && empty($usercanconsultsuppliers)) {
+        accessforbidden();
 }
 
 


### PR DESCRIPTION
## Summary
- ajouter une permission avancée "Consulter les prix d'achat" pour le module Produit et l'exposer dans les langues en_US et fr_FR
- permettre l'accès à l'onglet des prix d'achat lorsque cette permission est accordée, même sans droit de création
- documenter la nouvelle permission dans le ChangeLog

## Testing
- php -l htdocs/core/modules/modProduct.class.php
- php -l htdocs/core/lib/product.lib.php
- php -l htdocs/product/price_suppliers.php

------
https://chatgpt.com/codex/tasks/task_e_68e65fe71894832eb2c4d869cd789b60