### PR TITLE
Sécuriser la suppression d'un transfert de stock par vérification CSRF

### DIFF
--- a/htdocs/product/stock/stocktransfer/stocktransfer_card.php
+++ b/htdocs/product/stock/stocktransfer/stocktransfer_card.php
@@ -94,7 +94,6 @@ foreach ($object->fields as $key => $val) {
 }
 
 // Ensure delete-related actions require a valid CSRF token.
-// FR: Vérifie que les actions de suppression possèdent un jeton CSRF valide.
 if (in_array($action, array('delete', 'deleteline'), true)) {
 	$csrfToken = GETPOST('token', 'alphanohtml');
 	if (empty($csrfToken)) {
@@ -903,7 +902,6 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 				print '</td>';
 				print '<td class="right">';
 				// Ensure the delete line link embeds a CSRF token.
-				// FR: Garantit que le lien de suppression de ligne intègre un jeton CSRF.
 				$deleteLineUrl = $_SERVER["PHP_SELF"] . '?id=' . $id . '&action=deleteline&lineid=' . $line->id . '&token=' . newToken();
 				print '<a href="' . $deleteLineUrl . '">' . img_delete($langs->trans("Remove")) . '</a>';
 				print '</td>';

--- a/htdocs/product/stock/stocktransfer/stocktransfer_card.php
+++ b/htdocs/product/stock/stocktransfer/stocktransfer_card.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2017 		Laurent Destailleur  	<eldy@users.sourceforge.net>
  * Copyright (C) 2024-2025	MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024-2025  Frédéric France             <frederic.france@free.fr>
+ * Copyright (C) 2025          Pierre Ardoin            <developpeur@lesmetiersdubatiment.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -89,6 +90,22 @@ $search = array();
 foreach ($object->fields as $key => $val) {
 	if (GETPOST('search_'.$key, 'alpha')) {
 		$search[$key] = GETPOST('search_'.$key, 'alpha');
+	}
+}
+
+// Ensure delete action requires a valid CSRF token.
+// FR: Vérifie que l'action de suppression possède un jeton CSRF valide.
+if ($action === 'delete') {
+	$csrfToken = GETPOST('token', 'alphanohtml');
+	if (empty($csrfToken)) {
+		accessforbidden();
+	}
+	if (function_exists('hash_equals')) {
+		if (!hash_equals(currentToken(), $csrfToken)) {
+			accessforbidden();
+		}
+	} elseif (currentToken() !== $csrfToken) {
+		accessforbidden();
 	}
 }
 

--- a/htdocs/product/stock/stocktransfer/stocktransfer_card.php
+++ b/htdocs/product/stock/stocktransfer/stocktransfer_card.php
@@ -901,12 +901,12 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 				print '<a class="editfielda reposition" href="' . $_SERVER["PHP_SELF"] . '?id=' . $object->id . '&amp;action=editline&amp;lineid=' . $line->id . '#line_' . $line->id . '">';
 				print img_edit() . '</a>';
 				print '</td>';
-			print '<td class="right">';
-			// Ensure the delete line link embeds a CSRF token.
-			// FR: Garantit que le lien de suppression de ligne intègre un jeton CSRF.
-			$deleteLineUrl = $_SERVER["PHP_SELF"] . '?id=' . $id . '&action=deleteline&lineid=' . $line->id . '&token=' . newToken();
-			print '<a href="' . $deleteLineUrl . '">' . img_delete($langs->trans("Remove")) . '</a>';
-			print '</td>';
+				print '<td class="right">';
+				// Ensure the delete line link embeds a CSRF token.
+				// FR: Garantit que le lien de suppression de ligne intègre un jeton CSRF.
+				$deleteLineUrl = $_SERVER["PHP_SELF"] . '?id=' . $id . '&action=deleteline&lineid=' . $line->id . '&token=' . newToken();
+				print '<a href="' . $deleteLineUrl . '">' . img_delete($langs->trans("Remove")) . '</a>';
+				print '</td>';
 			}
 
 			$num = count($object->lines);

--- a/htdocs/product/stock/stocktransfer/stocktransfer_card.php
+++ b/htdocs/product/stock/stocktransfer/stocktransfer_card.php
@@ -93,18 +93,19 @@ foreach ($object->fields as $key => $val) {
 	}
 }
 
-// Ensure delete action requires a valid CSRF token.
-// FR: Vérifie que l'action de suppression possède un jeton CSRF valide.
-if ($action === 'delete') {
+// Ensure delete-related actions require a valid CSRF token.
+// FR: Vérifie que les actions de suppression possèdent un jeton CSRF valide.
+if (in_array($action, array('delete', 'deleteline'), true)) {
 	$csrfToken = GETPOST('token', 'alphanohtml');
 	if (empty($csrfToken)) {
 		accessforbidden();
 	}
+	$expectedToken = currentToken();
 	if (function_exists('hash_equals')) {
-		if (!hash_equals(currentToken(), $csrfToken)) {
+		if (!hash_equals($expectedToken, $csrfToken)) {
 			accessforbidden();
 		}
-	} elseif (currentToken() !== $csrfToken) {
+	} elseif ($expectedToken !== $csrfToken) {
 		accessforbidden();
 	}
 }
@@ -900,9 +901,12 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 				print '<a class="editfielda reposition" href="' . $_SERVER["PHP_SELF"] . '?id=' . $object->id . '&amp;action=editline&amp;lineid=' . $line->id . '#line_' . $line->id . '">';
 				print img_edit() . '</a>';
 				print '</td>';
-				print '<td class="right">';
-				print '<a href="' . $_SERVER["PHP_SELF"] . '?id=' . $id . '&action=deleteline&lineid=' . $line->id . '">' . img_delete($langs->trans("Remove")) . '</a>';
-				print '</td>';
+			print '<td class="right">';
+			// Ensure the delete line link embeds a CSRF token.
+			// FR: Garantit que le lien de suppression de ligne intègre un jeton CSRF.
+			$deleteLineUrl = $_SERVER["PHP_SELF"] . '?id=' . $id . '&action=deleteline&lineid=' . $line->id . '&token=' . newToken();
+			print '<a href="' . $deleteLineUrl . '">' . img_delete($langs->trans("Remove")) . '</a>';
+			print '</td>';
 			}
 
 			$num = count($object->lines);


### PR DESCRIPTION
## Résumé
- ajoute une vérification du jeton CSRF avant toute suppression de transfert de stock
- met à jour l'en-tête du fichier avec les informations développeur requises

## Tests
- `php -l htdocs/product/stock/stocktransfer/stocktransfer_card.php`


------
https://chatgpt.com/codex/tasks/task_e_68fb19d2e6c4832e96429a085f926aee