### PR TITLE
Fix signature box alignment in Soleil intervention PDF

### DIFF
--- a/htdocs/core/modules/fichinter/doc/pdf_soleil.modules.php
+++ b/htdocs/core/modules/fichinter/doc/pdf_soleil.modules.php
@@ -508,32 +508,35 @@ class pdf_soleil extends ModelePDFFicheinter
 				}
 			}
 
-						// EN: Keep the signature box and related labels on the same page by positioning them dynamically.
+			// EN: Keep the signature box and related labels on the same page by positioning them dynamically.
 			$signature_block_height = 30;
 			$page_break_trigger = $pdf->getPageHeight() - $pdf->getBreakMargin();
 			$signature_top = $tab_top + $tab_height - $signature_block_height - 5;
 			$signature_top = min($signature_top, $page_break_trigger - $signature_block_height);
 			$signature_top = max($signature_top, $tab_top + 5);
 
+			$signature_box_width = (($this->page_largeur - $this->marge_gauche - $this->marge_droite) - 15) / 2;
+			$signature_left_x = $this->marge_gauche + 5;
+			$signature_right_x = $signature_left_x + $signature_box_width + 5;
+
 			$previous_autopagebreak = $pdf->getAutoPageBreak();
 			$previous_breakmargin = $pdf->getBreakMargin();
 			$pdf->SetAutoPageBreak(false, 0);
 
-			$pdf->SetXY(20, $signature_top);
-			$pdf->MultiCell(80, 5, $outputlangs->transnoentities("NameAndSignatureOfInternalContact"), 0, 'L', 0);
+			$pdf->SetXY($signature_left_x, $signature_top);
+			$pdf->MultiCell($signature_box_width, 5, $outputlangs->transnoentities("NameAndSignatureOfInternalContact"), 0, 'L', 0);
 
-			$pdf->SetXY(20, $signature_top + 5);
-			$pdf->MultiCell(80, 25, $employee_name, 1, 'L');
+			$pdf->SetXY($signature_left_x, $signature_top + 5);
+			$pdf->MultiCell($signature_box_width, 25, $employee_name, 1, 'L');
 
-			$pdf->SetXY(110, $signature_top);
-			$pdf->MultiCell(80, 5, $outputlangs->transnoentities("NameAndSignatureOfExternalContact"), 0, 'L', 0);
+			$pdf->SetXY($signature_right_x, $signature_top);
+			$pdf->MultiCell($signature_box_width, 5, $outputlangs->transnoentities("NameAndSignatureOfExternalContact"), 0, 'L', 0);
 
-			$pdf->SetXY(110, $signature_top + 5);
-			$pdf->MultiCell(80, 25, '', 1);
+			$pdf->SetXY($signature_right_x, $signature_top + 5);
+			$pdf->MultiCell($signature_box_width, 25, '', 1);
 
 			$pdf->SetAutoPageBreak($previous_autopagebreak, $previous_breakmargin);
 		}
-	}
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**

--- a/htdocs/core/modules/fichinter/doc/pdf_soleil.modules.php
+++ b/htdocs/core/modules/fichinter/doc/pdf_soleil.modules.php
@@ -538,6 +538,8 @@ class pdf_soleil extends ModelePDFFicheinter
 			$pdf->SetAutoPageBreak($previous_autopagebreak, $previous_breakmargin);
 		}
 
+	}
+
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**
 	 *  Show top header of page.

--- a/htdocs/core/modules/fichinter/doc/pdf_soleil.modules.php
+++ b/htdocs/core/modules/fichinter/doc/pdf_soleil.modules.php
@@ -508,12 +508,14 @@ class pdf_soleil extends ModelePDFFicheinter
 				}
 			}
 
-					// EN: Keep the signature boxes aligned inside the rectangle while preventing page overflow.
+					// EN: Keep the signature boxes aligned inside the rectangle while preventing overflow.
 					$signature_block_height = 30;
+					$tab_bottom = $tab_top + $tab_height;
 					$page_break_trigger = $pdf->getPageHeight() - $pdf->getBreakMargin();
-					$content_bottom = max($nexY, $tab_top + 5);
-					$signature_top = $tab_top + $tab_height - $signature_block_height - 6;
-					$signature_top = max($signature_top, $content_bottom + 4);
+					$content_bottom = max($nexY, $tab_top + 6);
+					$signature_top = $tab_bottom - $signature_block_height - 6;
+					$signature_top = max($signature_top, $content_bottom + 2);
+					$signature_top = min($signature_top, $tab_bottom - $signature_block_height - 1);
 					$signature_top = min($signature_top, $page_break_trigger - $signature_block_height);
 
 					$available_signature_width = $this->page_largeur - $this->marge_gauche - $this->marge_droite;

--- a/htdocs/core/modules/fichinter/doc/pdf_soleil.modules.php
+++ b/htdocs/core/modules/fichinter/doc/pdf_soleil.modules.php
@@ -508,16 +508,19 @@ class pdf_soleil extends ModelePDFFicheinter
 				}
 			}
 
-			// EN: Keep the signature box and related labels on the same page by positioning them dynamically.
-			$signature_block_height = 30;
-			$page_break_trigger = $pdf->getPageHeight() - $pdf->getBreakMargin();
-			$signature_top = $tab_top + $tab_height - $signature_block_height - 5;
-			$signature_top = min($signature_top, $page_break_trigger - $signature_block_height);
-			$signature_top = max($signature_top, $tab_top + 5);
+					// EN: Keep the signature boxes aligned inside the rectangle while preventing page overflow.
+					$signature_block_height = 30;
+					$page_break_trigger = $pdf->getPageHeight() - $pdf->getBreakMargin();
+					$content_bottom = max($nexY, $tab_top + 5);
+					$signature_top = $tab_top + $tab_height - $signature_block_height - 6;
+					$signature_top = max($signature_top, $content_bottom + 4);
+					$signature_top = min($signature_top, $page_break_trigger - $signature_block_height);
 
-			$signature_box_width = (($this->page_largeur - $this->marge_gauche - $this->marge_droite) - 15) / 2;
-			$signature_left_x = $this->marge_gauche + 5;
-			$signature_right_x = $signature_left_x + $signature_box_width + 5;
+					$available_signature_width = $this->page_largeur - $this->marge_gauche - $this->marge_droite;
+					$signature_spacing = 5;
+					$signature_box_width = ($available_signature_width - $signature_spacing) / 2;
+					$signature_left_x = $this->marge_gauche;
+					$signature_right_x = $signature_left_x + $signature_box_width + $signature_spacing;
 
 			$previous_autopagebreak = $pdf->getAutoPageBreak();
 			$previous_breakmargin = $pdf->getBreakMargin();


### PR DESCRIPTION
## Summary
- reposition the Soleil intervention signature boxes using template margins so they stay inside the frame
- keep dynamic placement logic while balancing both signature columns

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c011b57d0832ebedec000cdbec00f)