### PR TITLE
feat(notification): add __AUTHOREMAIL__ substitution in notify recipients

### DIFF
--- a/htdocs/admin/notification.php
+++ b/htdocs/admin/notification.php
@@ -487,14 +487,14 @@ foreach ($listofnotifiedevents as $notifiedevent) {
 		$showwarning = 0;
 		foreach ($arrayemail as $keydet => $valuedet) {
 			$valuedet = trim($valuedet);
-			if (!empty($valuedet) && !isValidEmail($valuedet, 1)) {
+			if (!empty($valuedet) && $valuedet != '__SUPERVISOREMAIL__' && $valuedet != '__AUTHOREMAIL__' && !isValidEmail($valuedet, 1)) {
 				$showwarning++;
 			}
 		}
 		if (getDolGlobalString($param) && $showwarning) {
 			$s .= ' '.img_warning($langs->trans("ErrorBadEMail"));
 		}
-		print $form->textwithpicto($s, $langs->trans("YouCanUseCommaSeparatorForSeveralRecipients").'<br>'.$langs->trans("YouCanAlsoUseSupervisorKeyword"), 1, 'help', '', 0, 2);
+		print $form->textwithpicto($s, $langs->trans("YouCanUseCommaSeparatorForSeveralRecipients").'<br>'.$langs->trans("YouCanAlsoUseSupervisorKeyword").'<br>'.$langs->trans("YouCanAlsoUseAuthorKeyword"), 1, 'help', '', 0, 2);
 		print '<br>';
 
 		$inputfieldalreadyshown++;
@@ -502,7 +502,7 @@ foreach ($listofnotifiedevents as $notifiedevent) {
 	// New entry input fields
 	if (empty($inputfieldalreadyshown) || !$codehasnotrigger) {
 		$s = '<input type="text" class="minwidth200" name="NOTIF_'.$notifiedevent['code'].'_new_key" value="">'; // Do not use type="email" here, we must be able to enter a list of email with , separator.
-		print $form->textwithpicto($s, $langs->trans("YouCanUseCommaSeparatorForSeveralRecipients").'<br>'.$langs->trans("YouCanAlsoUseSupervisorKeyword"), 1, 'help', '', 0, 2);
+		print $form->textwithpicto($s, $langs->trans("YouCanUseCommaSeparatorForSeveralRecipients").'<br>'.$langs->trans("YouCanAlsoUseSupervisorKeyword").'<br>'.$langs->trans("YouCanAlsoUseAuthorKeyword"), 1, 'help', '', 0, 2);
 	}
 	print '</td>';
 

--- a/htdocs/core/class/notify.class.php
+++ b/htdocs/core/class/notify.class.php
@@ -582,17 +582,10 @@ class Notify
 					foreach ($tmpemail as $key2 => $val2) {
 						$newval2 = trim($val2);
 						if ($newval2 == '__SUPERVISOREMAIL__') {
-							if ($user->fk_user > 0) {
-								$tmpuser = new User($this->db);
-								$tmpuser->fetch($user->fk_user);
-								if ($tmpuser->email) {
-									$newval2 = trim($tmpuser->email);
-								} else {
-									$newval2 = '';
-								}
-							} else {
-								$newval2 = '';
-							}
+							$newval2 = $this->getSupervisorEmail();
+						}
+						if ($newval2 == '__AUTHOREMAIL__') {
+							$newval2 = $this->getAuthorEmail($object);
 						}
 						if ($newval2) {
 							$isvalid = isValidEmail($newval2, 0);
@@ -984,22 +977,8 @@ class Notify
 
 						$labeltouse = !empty($labeltouse) ? $labeltouse : '';
 
-						// Replace keyword __SUPERVISOREMAIL__
-						if (preg_match('/__SUPERVISOREMAIL__/', $sendto)) {
-							$newval = '';
-							if ($user->fk_user > 0) {
-								$supervisoruser = new User($this->db);
-								$supervisoruser->fetch($user->fk_user);
-								if ($supervisoruser->email) {
-									$newval = trim(dolGetFirstLastname($supervisoruser->firstname, $supervisoruser->lastname).' <'.$supervisoruser->email.'>');
-								}
-							}
-							dol_syslog("Replace the __SUPERVISOREMAIL__ key into recipient email string with ".$newval);
-							$sendto = preg_replace('/__SUPERVISOREMAIL__/', $newval, $sendto);
-							$sendto = preg_replace('/,\s*,/', ',', $sendto); // in some case you can have $sendto like "email, __SUPERVISOREMAIL__ , otheremail" then you have "email,  , othermail" and it's not valid
-							$sendto = preg_replace('/^[\s,]+/', '', $sendto); // Clean start of string
-							$sendto = preg_replace('/[\s,]+$/', '', $sendto); // Clean end of string
-						}
+						$sendto = $this->replaceSpecialRecipientToken($sendto, '__SUPERVISOREMAIL__', $this->getSupervisorEmail(1));
+						$sendto = $this->replaceSpecialRecipientToken($sendto, '__AUTHOREMAIL__', $this->getAuthorEmail($object, 1));
 
 						$parameters = array('notifcode' => $notifcode, 'sendto' => $sendto, 'from' => $from, 'file' => $filename_list, 'mimefile' => $mimetype_list, 'filename' => $mimefilename_list, 'outputlangs' => $outputlangs, 'labeltouse' => $labeltouse);
 						if (!isset($action)) {
@@ -1315,22 +1294,8 @@ class Notify
 					$message = nl2br($message);
 				}
 
-				// Replace keyword __SUPERVISOREMAIL__
-				if (preg_match('/__SUPERVISOREMAIL__/', $sendto)) {
-					$newval = '';
-					if ($user->fk_user > 0) {
-						$supervisoruser = new User($this->db);
-						$supervisoruser->fetch($user->fk_user);
-						if ($supervisoruser->email) {
-							$newval = trim(dolGetFirstLastname($supervisoruser->firstname, $supervisoruser->lastname).' <'.$supervisoruser->email.'>');
-						}
-					}
-					dol_syslog("Replace the __SUPERVISOREMAIL__ key into recipient email string with ".$newval);
-					$sendto = preg_replace('/__SUPERVISOREMAIL__/', $newval, $sendto);
-					$sendto = preg_replace('/,\s*,/', ',', $sendto); // in some case you can have $sendto like "email, __SUPERVISOREMAIL__ , otheremail" then you have "email,  , othermail" and it's not valid
-					$sendto = preg_replace('/^[\s,]+/', '', $sendto); // Clean start of string
-					$sendto = preg_replace('/[\s,]+$/', '', $sendto); // Clean end of string
-				}
+				$sendto = $this->replaceSpecialRecipientToken($sendto, '__SUPERVISOREMAIL__', $this->getSupervisorEmail(1));
+				$sendto = $this->replaceSpecialRecipientToken($sendto, '__AUTHOREMAIL__', $this->getAuthorEmail($object, 1));
 
 				if ($sendto) {
 					$parameters = array('notifcode' => $notifcode, 'sendto' => $sendto, 'from' => $from, 'file' => $filename_list, 'mimefile' => $mimetype_list, 'filename' => $mimefilename_list, 'subject' => &$subject, 'message' => &$message);
@@ -1392,5 +1357,97 @@ class Notify
 		} else {
 			return -1 * $error;
 		}
+	}
+
+	/**
+	 * Return supervisor email.
+	 *
+	 * @param	int<0,1>	$withLabel	1=Return "Firstname Lastname <email>", 0=Return "email"
+	 * @return	string
+	 */
+	private function getSupervisorEmail($withLabel = 0)
+	{
+		global $user;
+
+		if (empty($user->fk_user) || $user->fk_user <= 0) {
+			return '';
+		}
+
+		$supervisoruser = new User($this->db);
+		$supervisoruser->fetch($user->fk_user);
+		if (empty($supervisoruser->email)) {
+			return '';
+		}
+
+		if ($withLabel) {
+			return trim(dolGetFirstLastname($supervisoruser->firstname, $supervisoruser->lastname).' <'.$supervisoruser->email.'>');
+		}
+
+		return trim($supervisoruser->email);
+	}
+
+	/**
+	 * Return author email of object.
+	 *
+	 * @param	CommonObject|null	$object		Object used to resolve author
+	 * @param	int<0,1>			$withLabel	1=Return "Firstname Lastname <email>", 0=Return "email"
+	 * @return	string
+	 */
+	private function getAuthorEmail($object, $withLabel = 0)
+	{
+		if (!is_object($object)) {
+			return '';
+		}
+
+		$author = null;
+
+		if (isset($object->user_author) && is_object($object->user_author) && !empty($object->user_author->email)) {
+			$author = $object->user_author;
+		} else {
+			$authorid = 0;
+			foreach (array('fk_user_author', 'user_author_id', 'fk_user_creat') as $fieldname) {
+				if (!empty($object->$fieldname)) {
+					$authorid = (int) $object->$fieldname;
+					break;
+				}
+			}
+			if ($authorid > 0) {
+				$author = new User($this->db);
+				$author->fetch($authorid);
+			}
+		}
+
+		if (empty($author) || empty($author->email)) {
+			return '';
+		}
+
+		if ($withLabel) {
+			return trim(dolGetFirstLastname($author->firstname, $author->lastname).' <'.$author->email.'>');
+		}
+
+		return trim($author->email);
+	}
+
+	/**
+	 * Replace a special token inside recipient list.
+	 *
+	 * @param	string	$sendto			Recipient list
+	 * @param	string	$token			Token to replace
+	 * @param	string	$replacement	Replacement value
+	 * @return	string
+	 */
+	private function replaceSpecialRecipientToken($sendto, $token, $replacement)
+	{
+		if (!preg_match('/'.preg_quote($token, '/').'/', $sendto)) {
+			return $sendto;
+		}
+
+		dol_syslog("Replace the ".$token." key into recipient email string with ".$replacement);
+		$sendto = preg_replace('/'.preg_quote($token, '/').'/', $replacement, $sendto);
+		$sendto = preg_replace('/,\s*,/', ',', $sendto); // In some case you can have $sendto like "email, __SUPERVISOREMAIL__ , otheremail" then you have "email,  , othermail" and it's not valid
+		$sendto = preg_replace('/^[\s,]+/', '', $sendto); // Clean start of string
+		$sendto = preg_replace('/[\s,]+$/', '', $sendto); // Clean end of string
+
+		return $sendto;
 	}
 }

--- a/htdocs/langs/de_DE/mails.lang
+++ b/htdocs/langs/de_DE/mails.lang
@@ -152,6 +152,7 @@ MailSendSetupIs=Der E-Mail-Versand wurde auf '%s' konfiguriert. Dieser Modus kan
 MailSendSetupIs2=Sie müssen zuerst mit einem Admin-Konto im Menü %sStart - Einstellungen - E-Mails%s den Parameter <strong>'%s'</strong> auf den Modus '%s' ändern. Dann können Sie die Daten des SMTP-Servers von Ihrem Internetdienstanbieter eingeben und die E-Mail-Kampagnen-Funktion nutzen.
 MailSendSetupIs3=Bei Fragen über die Einrichtung Ihres SMTP-Servers, können Sie %s fragen.
 YouCanAlsoUseSupervisorKeyword=Sie können auch das Schlüsselwort <strong>__SUPERVISOREMAIL__</strong> eintragen, um E-Mails an den Vorgesetzten eines Benutzers zu senden (funktioniert nur, wenn eine E-Mail-Adresse für den jeweiligen Supervisor hinterlegt wurde)
+YouCanAlsoUseAuthorKeyword=Sie können auch das Schlüsselwort <strong>__AUTHOREMAIL__</strong> eintragen, um E-Mails an den Autor des Dokuments zu senden (funktioniert nur, wenn eine E-Mail-Adresse für diesen Autor hinterlegt wurde)
 NbOfTargetedContacts=Aktuelle Anzahl der E-Mails-Kontakte
 UseFormatFileEmailToTarget=Die importierte Datei muss im folgenden Format vorliegen:<br><strong>E-Mail-Adresse;Nachname;Vorname;Zusatzinformationen</strong>.
 UseFormatInputEmailToTarget=Geben Sie eine Zeichenkette im Format<br><strong>E-Mail-Adresse;Nachname;Vorname;Zusatzinformationen</strong> ein

--- a/htdocs/langs/en_US/mails.lang
+++ b/htdocs/langs/en_US/mails.lang
@@ -152,6 +152,7 @@ MailSendSetupIs=Configuration of email sending has been setup to '%s'. This mode
 MailSendSetupIs2=You must first go, with an admin account, into menu %sHome - Setup - EMails%s to change parameter <strong>'%s'</strong> to use mode '%s'. With this mode, you can enter setup of the SMTP server provided by your Internet Service Provider and use Mass emailing feature.
 MailSendSetupIs3=If you have any questions on how to setup your SMTP server, you can ask to %s.
 YouCanAlsoUseSupervisorKeyword=You can also add the keyword <strong>__SUPERVISOREMAIL__</strong> to have email being sent to the supervisor of user (works only if an email is defined for this supervisor)
+YouCanAlsoUseAuthorKeyword=You can also add the keyword <strong>__AUTHOREMAIL__</strong> to have email being sent to the author of the document (works only if an email is defined for this author)
 NbOfTargetedContacts=Current number of targeted contact emails
 UseFormatFileEmailToTarget=Imported file must have format <strong>email;name;firstname;other</strong>
 UseFormatInputEmailToTarget=Enter a string with format <strong>email;name;firstname;other</strong>

--- a/htdocs/langs/es_ES/mails.lang
+++ b/htdocs/langs/es_ES/mails.lang
@@ -152,6 +152,7 @@ MailSendSetupIs=La configuración de e-mailings está a '%s'. Este modo no puede
 MailSendSetupIs2=Antes debe, con una cuenta de administrador, en el menú %sInicio - Configuración - E-Mails%s, cambiar el parámetro <strong>'%s'</strong> para usar el modo '%s'. Con este modo puede configurar un servidor SMTP de su proveedor de servicios de internet.
 MailSendSetupIs3=Si tiene preguntas de como configurar su servidor SMTP, puede contactar con %s.
 YouCanAlsoUseSupervisorKeyword=Puede también añadir la etiqueta <strong>__SUPERVISOREMAIL__</strong> para tener un e-mail  enviado del supervisor al usuario (solamente funciona si un e-mail es definido para este supervisor)
+YouCanAlsoUseAuthorKeyword=También puede añadir la etiqueta <strong>__AUTHOREMAIL__</strong> para enviar el correo electrónico al autor del documento (solo funciona si se ha definido un correo para este autor)
 NbOfTargetedContacts=Número actual de contactos destinariarios de e-mails
 UseFormatFileEmailToTarget=Los ficheros importados deben tener el formato <strong>email;nombre;apellido;otros</strong>
 UseFormatInputEmailToTarget=Entra una cadena con el formato <strong>email;nombre;apellido;otros</strong>

--- a/htdocs/langs/fr_FR/mails.lang
+++ b/htdocs/langs/fr_FR/mails.lang
@@ -152,6 +152,7 @@ MailSendSetupIs=La configuration d'envoi d'emails a été définir sur '%s'. Ce 
 MailSendSetupIs2=Vous devez d'abord aller, avec un compte d'administrateur, dans le menu %sAccueil - Configuration - EMails%s pour changer le paramètre <strong>'%s'</strong> pour utiliser le mode '%s'. Avec ce mode, vous pouvez entrer le paramétrage du serveur SMTP fourni par votre fournisseur de services Internet et utiliser la fonction d'envoi d'email en masse.
 MailSendSetupIs3=Si vous avez des questions sur la façon de configurer votre serveur SMTP, vous pouvez demander à %s.
 YouCanAlsoUseSupervisorKeyword=Vous pouvez également ajouter le mot-clé <strong>__SUPERVISOREMAIL__</strong> pour avoir les emails envoyés au responsable hiérarchique de l'utilisateur (ne fonctionne que si un email est défini pour ce responsable)
+YouCanAlsoUseAuthorKeyword=Vous pouvez également ajouter le mot-clé <strong>__AUTHOREMAIL__</strong> pour avoir les emails envoyés à l'auteur du document (ne fonctionne que si un email est défini pour cet auteur)
 NbOfTargetedContacts=Nombre courant d'emails de contacts cibles
 UseFormatFileEmailToTarget=Le fichier d'import doit être au format <strong>email;name;firstname;other</strong>
 UseFormatInputEmailToTarget=Saisissez une chaîne de caractères au format <strong>email;nom;prénom;autre</strong>

--- a/htdocs/langs/it_IT/mails.lang
+++ b/htdocs/langs/it_IT/mails.lang
@@ -150,6 +150,7 @@ MailSendSetupIs=La configurazione della posta elettronica di invio è stata impo
 MailSendSetupIs2=Con un account da amministratore è necessario cliccare su %sHome -> Setup -> EMails%s e modificare il parametro <strong>'%s'</strong> per usare la modalità '%s'. Con questa modalità è possibile inserire i dati del server SMTP di elezione e usare Il "Mass Emailing"
 MailSendSetupIs3=Se hai domande su come configurare il tuo server SMTP chiedi a %s.
 YouCanAlsoUseSupervisorKeyword=È inoltre possibile aggiungere la parola chiave <strong>__SUPERVISOREMAIL__</strong> per inviare email  al supervisore dell'utente (funziona solo se è definita una email per suddetto supervisor)
+YouCanAlsoUseAuthorKeyword=È inoltre possibile aggiungere la parola chiave <strong>__AUTHOREMAIL__</strong> per inviare email all'autore del documento (funziona solo se è definita una email per questo autore)
 NbOfTargetedContacts=Numero di indirizzi di posta elettronica di contatti mirati
 UseFormatFileEmailToTarget=Imported file must have format <strong>email;name;firstname;other</strong>
 UseFormatInputEmailToTarget=Enter a string with format <strong>email;name;firstname;other</strong>


### PR DESCRIPTION
### Motivation
- Permettre l'utilisation de la variable de substitution `__AUTHOREMAIL__` pour notifier l'auteur d'un document (devis, commande, etc.) via la configuration `NOTIFICATION_FIXEDEMAIL_*` comme c'est déjà possible pour `__SUPERVISOREMAIL__`.
- Rationaliser et factoriser le code de remplacement des tokens destinataires pour éviter les duplications et centraliser la logique.

### Description
- Ajout de la détection et résolution de `__AUTHOREMAIL__` dans `Notify::getNotificationsArray()` pour les emails fixes de notifications.
- Factorisation du remplacement des tokens dans `Notify::send()` en introduisant trois méthodes privées : `getSupervisorEmail()`, `getAuthorEmail()` et `replaceSpecialRecipientToken()`.
- `getAuthorEmail()` tente de retrouver l'auteur via `user_author` ou via les champs usuels `fk_user_author`, `user_author_id`, `fk_user_creat` et retourne soit `email` soit `Firstname Lastname <email>` selon le mode demandé.
- Les remplacements nettoient la chaîne destinataires (suppression des virgules vides et espaces superflus) et conservent le comportement existant pour `__SUPERVISOREMAIL__`.

### Testing
- Vérification de la syntaxe PHP avec `php -l htdocs/core/class/notify.class.php`, qui a réussi sans erreurs.
- Inspection rapide des occurrences de `__AUTHOREMAIL__`, `getAuthorEmail`, `getSupervisorEmail` et `replaceSpecialRecipientToken` pour valider l’application des changements (checks statiques réalisés pendant la mise en place).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69962df2bc04832e9cc74933f2214ef5)