### PR TITLE
webportal: prise en charge multicompany des documents et ajout de la liste des contrats clients

### DIFF
--- a/htdocs/langs/de_DE/website.lang
+++ b/htdocs/langs/de_DE/website.lang
@@ -191,6 +191,7 @@ WebPortalPartnerShipCardAccessHelp=Zugriff auf den Partnerschaftsdatensatz (vers
 WEBPORTAL_PROPAL_LIST_ACCESS=Zugriff auf die Angebote ermöglichen
 WEBPORTAL_ORDER_LIST_ACCESS=Zugriff auf die Bestellungen aktivieren
 WEBPORTAL_INVOICE_LIST_ACCESS=Zugriff auf die Rechnungen aktivieren
+WEBPORTAL_CONTRACT_LIST_ACCESS=Zugriff auf Kundenverträge aktivieren
 WEBPORTAL_USER_LOGGED=Einen anonymen Benutzer wählen
 WebPortalUserLoggedHelp=Dieser Benutzer wird verwendet, um Daten in Karten zu aktualisieren.
 WebPortalHomeTitle=Willkommen
@@ -479,3 +480,7 @@ WebPortalSharedDocsDirHelp=Namen der Verzeichnisses eingeben, das sich im Ordner
 DateM=Änderungsdatum
 ThisDirectoryIsEmpty=Dieses Verzeichnis ist leer
 WrittenBy=Geschrieben von %s
+
+WebPortalContractListMenu=Verträge
+WebPortalContractListTitle=Kundenverträge
+WebPortalContractListDesc=Liste meiner Kundenverträge

--- a/htdocs/langs/en_US/website.lang
+++ b/htdocs/langs/en_US/website.lang
@@ -191,6 +191,7 @@ WebPortalPartnerShipCardAccessHelp=Enable access to the partnership record (Hidd
 WEBPORTAL_PROPAL_LIST_ACCESS=Enable access to the proposals
 WEBPORTAL_ORDER_LIST_ACCESS=Enable access to the orders
 WEBPORTAL_INVOICE_LIST_ACCESS=Enable access to the invoices
+WEBPORTAL_CONTRACT_LIST_ACCESS=Enable access to the customer contracts
 WEBPORTAL_USER_LOGGED=Select an anonymous user
 WebPortalUserLoggedHelp=This user is used to update cards
 WebPortalHomeTitle=Welcome
@@ -479,3 +480,7 @@ WebPortalSharedDocsDirHelp=Enter the name of the directory, located in the ECM/G
 DateM=Modification Date
 ThisDirectoryIsEmpty=This directory is empty
 WrittenBy=Written by %s
+
+WebPortalContractListMenu=Contracts
+WebPortalContractListTitle=Customer contracts
+WebPortalContractListDesc=List of my customer contracts

--- a/htdocs/langs/es_ES/website.lang
+++ b/htdocs/langs/es_ES/website.lang
@@ -191,6 +191,7 @@ WebPortalPartnerShipCardAccessHelp=Habilitar el acceso al registro de sociedad (
 WEBPORTAL_PROPAL_LIST_ACCESS=Habilitar el acceso a los presupuestos
 WEBPORTAL_ORDER_LIST_ACCESS=Habilitar el acceso a los pedidos
 WEBPORTAL_INVOICE_LIST_ACCESS=Habilitar el acceso a las facturas
+WEBPORTAL_CONTRACT_LIST_ACCESS=Habilitar el acceso a los contratos de cliente
 WEBPORTAL_USER_LOGGED=Seleccione un usuario anónimo
 WebPortalUserLoggedHelp=Este usuario se utiliza para actualizar tarjetas.
 WebPortalHomeTitle=Bienvenido
@@ -479,3 +480,7 @@ WebPortalSharedDocsDirHelp=Ingrese el nombre del directorio, ubicado en la carpe
 DateM=Fecha de modificación
 ThisDirectoryIsEmpty=Este directorio está vacío
 WrittenBy=Escrito por %s
+
+WebPortalContractListMenu=Contratos
+WebPortalContractListTitle=Contratos de clientes
+WebPortalContractListDesc=Lista de mis contratos de clientes

--- a/htdocs/langs/fr_FR/website.lang
+++ b/htdocs/langs/fr_FR/website.lang
@@ -191,6 +191,7 @@ WebPortalPartnerShipCardAccessHelp=Autoriser l'accès à l'enregistrement des pa
 WEBPORTAL_PROPAL_LIST_ACCESS=Autoriser l'accès aux devis
 WEBPORTAL_ORDER_LIST_ACCESS=Autoriser l'accès aux commandes
 WEBPORTAL_INVOICE_LIST_ACCESS=Autoriser l'accès aux factures
+WEBPORTAL_CONTRACT_LIST_ACCESS=Activer l'accès aux contrats clients
 WEBPORTAL_USER_LOGGED=Sélectionnez un utilisateur anonyme
 WebPortalUserLoggedHelp=Cet utilisateur est utilisé pour mettre à jour les fiches.
 WebPortalHomeTitle=Bienvenue
@@ -479,3 +480,7 @@ WebPortalSharedDocsDirHelp=Saisissez le nom du répertoire, situé dans le dossi
 DateM=Date de modification
 ThisDirectoryIsEmpty=Ce répertoire est vide.
 WrittenBy=Écrit par %s
+
+WebPortalContractListMenu=Contrats
+WebPortalContractListTitle=Contrats clients
+WebPortalContractListDesc=Liste de mes contrats clients

--- a/htdocs/langs/it_IT/website.lang
+++ b/htdocs/langs/it_IT/website.lang
@@ -191,6 +191,7 @@ WebPortalPartnerShipCardAccessHelp=Abilita l'accesso al record della partnership
 WEBPORTAL_PROPAL_LIST_ACCESS=Abilita l'accesso a Proposte
 WEBPORTAL_ORDER_LIST_ACCESS=Abilita l'accesso agli ordini
 WEBPORTAL_INVOICE_LIST_ACCESS=Abilita l'accesso a fatture
+WEBPORTAL_CONTRACT_LIST_ACCESS=Abilita l'accesso ai contratti cliente
 WEBPORTAL_USER_LOGGED=Seleziona un utente anonimo
 WebPortalUserLoggedHelp=Questo utente viene utilizzato per aggiornare le carte
 WebPortalHomeTitle=Benvenuto
@@ -479,3 +480,7 @@ WebPortalSharedDocsDirHelp=Enter the name of the directory, located in the ECM/G
 DateM=Modification Date
 ThisDirectoryIsEmpty=This directory is empty
 WrittenBy=Written by %s
+
+WebPortalContractListMenu=Contratti
+WebPortalContractListTitle=Contratti clienti
+WebPortalContractListDesc=Elenco dei miei contratti clienti

--- a/htdocs/public/webportal/tpl/home.tpl.php
+++ b/htdocs/public/webportal/tpl/home.tpl.php
@@ -37,5 +37,11 @@ if (empty($context) || !is_object($context)) {
 				<?php print '<a class="home-links-card__link" href="' . $context->getControllerUrl('invoicelist') . '" title="' . $langs->trans('WebPortalInvoiceListDesc') . '">' . $langs->trans('WebPortalInvoiceListTitle') . '</a>'; ?>
 			</article>
 			<?php endif; ?>
+			<?php if (isModEnabled('contract') && getDolGlobalInt('WEBPORTAL_CONTRACT_LIST_ACCESS')) : ?>
+			<article class="home-links-card --contract-list">
+				<div class="home-links-card__icon" ></div>
+				<?php print '<a class="home-links-card__link" href="' . $context->getControllerUrl('contractlist') . '" title="' . $langs->trans('WebPortalContractListDesc') . '">' . $langs->trans('WebPortalContractListTitle') . '</a>'; ?>
+			</article>
+			<?php endif; ?>
 		</div>
 </main>

--- a/htdocs/public/webportal/tpl/menu.tpl.php
+++ b/htdocs/public/webportal/tpl/menu.tpl.php
@@ -62,6 +62,16 @@ if ($context->userIsLog()) {
 			'group' => 'administrative' // group identifier for the group if necessary
 		);
 	}
+	// menu contracts
+	if (isModEnabled('contract') && getDolGlobalInt('WEBPORTAL_CONTRACT_LIST_ACCESS')) {
+		$navMenu['contract_list'] = array(
+			'id' => 'contract_list',
+			'rank' => 35,
+			'url' => $context->getControllerUrl('contractlist'),
+			'name' => $langs->trans('WebPortalContractListMenu'),
+			'group' => 'administrative' // group identifier for the group if necessary
+		);
+	}
 	// menu documents (GED)
 	if (getDolGlobalInt('WEBPORTAL_DOCUMENT_LIST_ACCESS')) {
 		$navMenu['document_list'] = array(

--- a/htdocs/webportal/class/context.class.php
+++ b/htdocs/webportal/class/context.class.php
@@ -253,6 +253,7 @@ class Context
 		$this->addControllerDefinition('propallist', $defaultControllersPath . 'propallist.controller.class.php', 'PropalListController');
 		$this->addControllerDefinition('orderlist', $defaultControllersPath . 'orderlist.controller.class.php', 'OrderListController');
 		$this->addControllerDefinition('invoicelist', $defaultControllersPath . 'invoicelist.controller.class.php', 'InvoiceListController');
+		$this->addControllerDefinition('contractlist', $defaultControllersPath . 'contractlist.controller.class.php', 'ContractListController');
 		$this->addControllerDefinition('membercard', $defaultControllersPath . 'membercard.controller.class.php', 'MemberCardController');
 		$this->addControllerDefinition('partnershipcard', $defaultControllersPath . 'partnershipcard.controller.class.php', 'PartnershipCardController');
 		//** below the addition of DocumentListController adding files by third party attached documents

--- a/htdocs/webportal/class/html.formlistwebportal.class.php
+++ b/htdocs/webportal/class/html.formlistwebportal.class.php
@@ -277,7 +277,7 @@ class FormListWebPortal
 			}
 		}
 		$this->arrayfields['remain_to_pay'] = array('type' => 'price', 'label' => 'RemainderToPay', 'checked' => 1, 'enabled' => $this->element == 'invoice' && isModEnabled('invoice'), 'visible' => 1, 'position' => 10000, 'help' => '',);
-		$this->arrayfields['download_link'] = array('type' => '', 'label' => 'File', 'checked' => 1, 'enabled' => ($this->element == 'propal' && isModEnabled('propal')) || ($this->element == 'order' && isModEnabled('order')) || ($this->element == 'invoice' && isModEnabled('invoice')), 'visible' => 1, 'position' => 10001, 'help' => '',);
+		$this->arrayfields['download_link'] = array('type' => '', 'label' => 'File', 'checked' => 1, 'enabled' => ($this->element == 'propal' && isModEnabled('propal')) || ($this->element == 'order' && isModEnabled('order')) || ($this->element == 'invoice' && isModEnabled('invoice')) || ($this->element == 'contract' && isModEnabled('contract')), 'visible' => 1, 'position' => 10001, 'help' => '',);
 		$this->arrayfields['signature_link'] = array('type' => '', 'label' => 'Signature', 'checked' => 1, 'enabled' => $this->element == 'propal' && isModEnabled('propal') && getDolGlobalString("PROPOSAL_ALLOW_ONLINESIGN") != 0, 'visible' => 1, 'position' => 10002, 'help' => '',);
 
 		$this->controller->listSetArrayFields();
@@ -660,7 +660,7 @@ class FormListWebPortal
 		if (is_object($this->object)) {
 			$out = $this->controller->listPrintValueBefore($field_key, $field_spec, $record);
 			if (empty($out)) {
-				if ($field_key == 'status' || $field_key == 'fk_statut') {
+				if ($field_key == 'status' || $field_key == 'fk_statut' || $field_key == 'statut') {
 					if ($this->element == 'invoice') {
 						// specific to get invoice status (depends on payment)
 						$out = $this->object->getLibStatut(5, $record->invoice_payment);
@@ -675,9 +675,14 @@ class FormListWebPortal
 					}
 				} elseif ($field_key == 'download_link') {
 					$element = $this->element;
+					$documentmodulepart = $element;
+					if ($element == 'contract') {
+						$element = 'contrat';
+						$documentmodulepart = 'contrat';
+					}
 					$filename = dol_sanitizeFileName($this->object->ref);
 					$filedir = $conf->{$element}->multidir_output[$this->object->entity] . '/' . dol_sanitizeFileName($this->object->ref);
-					$out = $this->form->getDocumentsLink($element, $filename, $filedir);
+					$out = $this->form->getDocumentsLink($documentmodulepart, $filename, $filedir);
 				} elseif ($field_key == 'signature_link') {
 					if ($this->object->fk_statut == Propal::STATUS_VALIDATED) {
 						$out = $this->form->getSignatureLink('proposal', $this->object);

--- a/htdocs/webportal/class/html.formlistwebportal.class.php
+++ b/htdocs/webportal/class/html.formlistwebportal.class.php
@@ -678,7 +678,7 @@ class FormListWebPortal
 					$documentmodulepart = $element;
 					if ($element == 'contract') {
 						$element = 'contrat';
-						$documentmodulepart = 'contrat';
+						$documentmodulepart = 'contract';
 					}
 					$filename = dol_sanitizeFileName($this->object->ref);
 					$filedir = $conf->{$element}->multidir_output[$this->object->entity] . '/' . dol_sanitizeFileName($this->object->ref);

--- a/htdocs/webportal/class/html.formlistwebportal.class.php
+++ b/htdocs/webportal/class/html.formlistwebportal.class.php
@@ -681,7 +681,9 @@ class FormListWebPortal
 						$documentmodulepart = 'contract';
 					}
 					$filename = dol_sanitizeFileName($this->object->ref);
-					$filedir = $conf->{$element}->multidir_output[$this->object->entity] . '/' . dol_sanitizeFileName($this->object->ref);
+					$entity = (!empty($this->object->entity) ? (int) $this->object->entity : (int) $conf->entity);
+					$diroutput = (!empty($conf->{$element}->multidir_output[$entity]) ? $conf->{$element}->multidir_output[$entity] : $conf->{$element}->dir_output);
+					$filedir = $diroutput . '/' . dol_sanitizeFileName($this->object->ref);
 					$out = $this->form->getDocumentsLink($documentmodulepart, $filename, $filedir);
 				} elseif ($field_key == 'signature_link') {
 					if ($this->object->fk_statut == Propal::STATUS_VALIDATED) {

--- a/htdocs/webportal/class/webportalcontract.class.php
+++ b/htdocs/webportal/class/webportalcontract.class.php
@@ -1,0 +1,71 @@
+<?php
+/* Copyright (C) 2026		Pierre Ardoin				<developpeur@lesmetiersdubatiment.fr>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file		htdocs/webportal/class/webportalcontract.class.php
+ * \ingroup	webportal
+ * \brief		This file is a CRUD class file for WebPortalContract.
+ */
+
+require_once DOL_DOCUMENT_ROOT . '/contrat/class/contrat.class.php';
+
+/**
+ * Class for WebPortalContract
+ */
+class WebPortalContract extends Contrat
+{
+	/**
+	 * @var string ID of module.
+	 */
+	public $module = 'webportal';
+
+	/**
+	 * Status list (short label)
+	 */
+	const ARRAY_STATUS_LABEL = array(
+		0 => 'StatusDraftShort',
+		1 => 'Validated',
+		2 => 'Closed',
+	);
+
+	/**
+	 *  Definition of fields for list rendering.
+	 *
+	 * @var array<string,array<string,mixed>>
+	 */
+	public $fields = array(
+		'rowid' => array('type' => 'integer', 'label' => 'TechnicalID', 'enabled' => 1, 'visible' => 0, 'notnull' => 1, 'position' => 10,),
+		'entity' => array('type' => 'integer', 'label' => 'Entity', 'default' => '1', 'enabled' => 1, 'visible' => -2, 'notnull' => 1, 'position' => 20, 'index' => 1,),
+		'ref' => array('type' => 'varchar(30)', 'label' => 'Ref', 'enabled' => 1, 'visible' => 2, 'notnull' => 1, 'showoncombobox' => 1, 'position' => 25,),
+		'date_contrat' => array('type' => 'date', 'label' => 'DateContract', 'enabled' => 1, 'visible' => 2, 'position' => 60,),
+		'date_fin_validite' => array('type' => 'date', 'label' => 'DateEnd', 'enabled' => 1, 'visible' => 2, 'position' => 70,),
+		'total_ht' => array('type' => 'price', 'label' => 'TotalHT', 'enabled' => 1, 'visible' => 2, 'position' => 125, 'isameasure' => 1,),
+		'total_tva' => array('type' => 'price', 'label' => 'VAT', 'enabled' => 1, 'visible' => 2, 'position' => 130, 'isameasure' => 1,),
+		'total_ttc' => array('type' => 'price', 'label' => 'TotalTTC', 'enabled' => 1, 'visible' => 2, 'position' => 145, 'isameasure' => 1,),
+		'statut' => array('type' => 'smallint(6)', 'label' => 'Status', 'enabled' => 1, 'visible' => 2, 'position' => 500, 'arrayofkeyval' => self::ARRAY_STATUS_LABEL,),
+	);
+
+	/**
+	 * Constructor
+	 *
+	 * @param	DoliDB	$db		Database handler
+	 */
+	public function __construct(DoliDB $db)
+	{
+		parent::__construct($db);
+	}
+}

--- a/htdocs/webportal/class/webportalcontract.class.php
+++ b/htdocs/webportal/class/webportalcontract.class.php
@@ -45,7 +45,7 @@ class WebPortalContract extends Contrat
 	/**
 	 *  Definition of fields for list rendering.
 	 *
-	 * @var array<string,array<string,mixed>>
+	 * @var array<string,array{type:string,label:string,langfile?:string,enabled:int<0,2>|string,position:int,notnull?:int,visible:int<-6,6>|string,alwayseditable?:int<0,1>|string,noteditable?:int<0,1>,default?:string,index?:int,foreignkey?:string,searchall?:int<0,1>,isameasure?:int<0,1>,css?:string,cssview?:string,csslist?:string,help?:string,showoncombobox?:int<0,4>|string,disabled?:int<0,1>,arrayofkeyval?:array<int|string,string>,autofocusoncreate?:int<0,1>,comment?:string,copytoclipboard?:int<1,2>,validate?:int<0,1>,showonheader?:int<0,1>,searchmulti?:int<0,1>}>
 	 */
 	public $fields = array(
 		'rowid' => array('type' => 'integer', 'label' => 'TechnicalID', 'enabled' => 1, 'visible' => 0, 'notnull' => 1, 'position' => 10,),

--- a/htdocs/webportal/class/webportalcontract.class.php
+++ b/htdocs/webportal/class/webportalcontract.class.php
@@ -52,7 +52,7 @@ class WebPortalContract extends Contrat
 		'entity' => array('type' => 'integer', 'label' => 'Entity', 'default' => '1', 'enabled' => 1, 'visible' => -2, 'notnull' => 1, 'position' => 20, 'index' => 1,),
 		'ref' => array('type' => 'varchar(30)', 'label' => 'Ref', 'enabled' => 1, 'visible' => 2, 'notnull' => 1, 'showoncombobox' => 1, 'position' => 25,),
 		'date_contrat' => array('type' => 'date', 'label' => 'DateContract', 'enabled' => 1, 'visible' => 2, 'position' => 60,),
-		'date_fin_validite' => array('type' => 'date', 'label' => 'DateEnd', 'enabled' => 1, 'visible' => 2, 'position' => 70,),
+		'denormalized_lower_planned_end_date' => array('type' => 'date', 'label' => 'DateEnd', 'enabled' => 1, 'visible' => 2, 'position' => 70,),
 		'total_ht' => array('type' => 'price', 'label' => 'TotalHT', 'enabled' => 1, 'visible' => 2, 'position' => 125, 'isameasure' => 1,),
 		'total_tva' => array('type' => 'price', 'label' => 'VAT', 'enabled' => 1, 'visible' => 2, 'position' => 130, 'isameasure' => 1,),
 		'total_ttc' => array('type' => 'price', 'label' => 'TotalTTC', 'enabled' => 1, 'visible' => 2, 'position' => 145, 'isameasure' => 1,),

--- a/htdocs/webportal/controllers/contractlist.controller.class.php
+++ b/htdocs/webportal/controllers/contractlist.controller.class.php
@@ -1,0 +1,109 @@
+<?php
+/* Copyright (C) 2026		Pierre Ardoin				<developpeur@lesmetiersdubatiment.fr>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file		htdocs/webportal/controllers/contractlist.controller.class.php
+ * \ingroup	webportal
+ * \brief		This file is a controller for contract list.
+ */
+
+require_once DOL_DOCUMENT_ROOT . '/webportal/class/html.formlistwebportal.class.php';
+require_once DOL_DOCUMENT_ROOT . '/webportal/controllers/abstractlist.controller.class.php';
+
+/**
+ * Class for ContractListController
+ */
+class ContractListController extends AbstractListController
+{
+	/**
+	 * Check current access to controller.
+	 *
+	 * @return	bool
+	 */
+	public function checkAccess()
+	{
+		$this->accessRight = isModEnabled('contract') && getDolGlobalInt('WEBPORTAL_CONTRACT_LIST_ACCESS');
+
+		return parent::checkAccess();
+	}
+
+	/**
+	 * Action method is called before html output.
+	 *
+	 * @return	int		Return integer < 0 on error, > 0 on success
+	 */
+	public function action()
+	{
+		global $langs;
+
+		$context = Context::getInstance();
+		if (!$context->controllerInstance->checkAccess()) {
+			return -1;
+		}
+
+		$langs->loadLangs(array('contracts', 'companies', 'products', 'categories'));
+
+		$context->title = $langs->trans('WebPortalContractListTitle');
+		$context->desc = $langs->trans('WebPortalContractListDesc');
+		$context->menu_active[] = 'contract_list';
+
+		$this->formList = new FormListWebPortal($this->db);
+		$this->formList->init($this, 'contract');
+
+		$hookRes = $this->hookDoAction();
+		if (empty($hookRes)) {
+			$this->formList->doActions();
+		}
+
+		$sqlBody = " AND t.fk_soc = " . ((int) $context->logged_thirdparty->id);
+		$sqlBody .= " AND t.statut <> 0";
+		$this->formList->setSqlRequest('', $sqlBody);
+
+		$this->formList->loadRecords();
+		$this->formList->setParams();
+		$this->formList->setColumnsVisibility();
+
+		return 1;
+	}
+
+	/**
+	 * Display
+	 *
+	 * @return	void
+	 */
+	public function display()
+	{
+		$context = Context::getInstance();
+		if (!$context->controllerInstance->checkAccess()) {
+			$this->display404();
+			return;
+		}
+
+		$this->loadTemplate('header');
+		$this->loadTemplate('menu');
+		$this->loadTemplate('hero-header-banner');
+
+		$hookRes = $this->hookPrintPageView();
+		if (empty($hookRes)) {
+			print '<main class="container">';
+			$this->loadTemplate('list');
+			print '</main>';
+		}
+
+		$this->loadTemplate('footer');
+	}
+}

--- a/htdocs/webportal/controllers/documentlist.controller.class.php
+++ b/htdocs/webportal/controllers/documentlist.controller.class.php
@@ -92,7 +92,9 @@ class DocumentListController extends AbstractDocumentController
 			// 1. Prepare data
 			require_once DOL_DOCUMENT_ROOT . '/core/lib/functions.lib.php';
 			$client_dir_name = dol_sanitizeFileName($thirdparty->ref);
-			$dir_ged_tiers = $conf->societe->dir_output . '/' . $client_dir_name;
+			$entity = (!empty($thirdparty->entity) ? (int) $thirdparty->entity : (int) $conf->entity);
+			$dir_output_societe = (!empty($conf->societe->multidir_output[$entity]) ? $conf->societe->multidir_output[$entity] : $conf->societe->dir_output);
+			$dir_ged_tiers = $dir_output_societe . '/' . $client_dir_name;
 			$fileList = dol_dir_list($dir_ged_tiers, 'files', 0, '', '', 'date', SORT_DESC);
 
 			// 2. Define the link builder function
@@ -102,8 +104,8 @@ class DocumentListController extends AbstractDocumentController
 			 * @param	array<string, mixed> $file  File (array) to get url for
 			 * @return	string						Url for file
 			 */
-			$linkBuilder = static function (array $file) use ($client_dir_name) {
-				return DOL_URL_ROOT . '/document.php?modulepart=societe&attachment=1&file=' . urlencode($client_dir_name . '/' . $file['name']);
+			$linkBuilder = static function (array $file) use ($client_dir_name, $entity) {
+				return DOL_URL_ROOT . '/document.php?modulepart=societe&entity=' . ((int) $entity) . '&attachment=1&file=' . urlencode($client_dir_name . '/' . $file['name']);
 			};
 
 			// 3. Encapsulate the link builder in an array, as required by displayDocumentTable


### PR DESCRIPTION
### Motivation

- Permettre la gestion multicompany des fichiers PDF / pièces jointes affichés dans le WebPortal en lisant le répertoire `multidir_output` de l'entité du tiers et en incluant `entity` dans les URLs de téléchargement.
- Offrir l'accès aux contrats clients depuis le WebPortal pour que les clients puissent consulter leurs contrats de manière similaire aux devis / commandes / factures.

### Description

- Ajout de la résolution du répertoire GED par entité dans `htdocs/webportal/controllers/documentlist.controller.class.php`: on utilise l'`entity` du tiers et `conf->societe->multidir_output[$entity]` si défini, et la génération d'URL de téléchargement inclut maintenant `&entity=`.
- Ajout d'une liste de contrats clients : nouveau contrôleur `htdocs/webportal/controllers/contractlist.controller.class.php` et nouvelle classe wrapper `htdocs/webportal/class/webportalcontract.class.php` basée sur `Contrat` pour exposer les champs utiles en liste.
- Enregistrement du nouveau contrôleur dans `htdocs/webportal/class/context.class.php` et ajout d'une entrée de menu dans `htdocs/public/webportal/tpl/menu.tpl.php` protégée par la constante de setup `WEBPORTAL_CONTRACT_LIST_ACCESS`.
- Adaptation de la génération des colonnes/listes dans `htdocs/webportal/class/html.formlistwebportal.class.php` pour : activer la colonne `download_link` pour les `contract`, prendre en charge le champ `statut` et mapper `contract` → `contrat` pour l'utilisation de `multidir_output` et `getDocumentsLink`.
- Ajout des clés de traduction nécessaires pour `en_US`, `fr_FR`, `de_DE`, `es_ES` et `it_IT` : `WEBPORTAL_CONTRACT_LIST_ACCESS`, `WebPortalContractListMenu`, `WebPortalContractListTitle`, `WebPortalContractListDesc`.

### Testing

- Vérification syntaxique PHP : `php -l` exécuté sur les fichiers modifiés/ajoutés (`documentlist.controller`, `contractlist.controller`, `webportalcontract.class`, `context.class`, `html.formlistwebportal.class`, `menu.tpl.php`) — aucune erreur détectée.
- Test front automatisé (capture via Playwright) tenté mais échoué pour cause d'environnement (aucun service HTTP accessible : `ERR_EMPTY_RESPONSE` sur `http://localhost/`), ce test n'a pas pu valider l'affichage visuel.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b87bf47ea8832eb8a5e506d4c84c62)