### PR TITLE
Include StockTransfer in project referents and load stocks lang for stocktransfer module

### DIFF
--- a/htdocs/core/lib/project.lib.php
+++ b/htdocs/core/lib/project.lib.php
@@ -193,6 +193,9 @@ function project_prepare_head(Project $project, $moreparam = '')
 			if (isModEnabled('project')) {
 				$nbElements += $project->getElementCount('project_task', 'projet_task');
 			}
+			if (isModEnabled('stocktransfer')) {
+				$nbElements += $project->getElementCount('stocktransfer', 'stocktransfer_stocktransfer', 'fk_project');
+			}
 			if (isModEnabled('stock')) {
 				$nbElements += $project->getElementCount('stock_mouvement', 'stock');
 			}

--- a/htdocs/langs/de_DE/stocks.lang
+++ b/htdocs/langs/de_DE/stocks.lang
@@ -31,6 +31,7 @@ ErrorWarehouseRefRequired=Warenlager-Referenz erforderlich
 MovementId=Bewegungs ID
 StockMovementForId=Lagerbewegung Nr. %d
 ListMouvementStockProject=Liste der mit dem Projekt verbundenen Lagerbewegungen
+ListStockTransferProject=Liste der mit dem Projekt verknüpften Lagertransfers
 StocksArea=Warenlager – Übersicht
 AllWarehouses=Alle Warenlager
 IncludeEmptyDesiredStock=Schließe auch negative Bestände mit undefinierten gewünschten Beständen ein

--- a/htdocs/langs/de_DE/stocks.lang
+++ b/htdocs/langs/de_DE/stocks.lang
@@ -32,6 +32,7 @@ MovementId=Bewegungs ID
 StockMovementForId=Lagerbewegung Nr. %d
 ListMouvementStockProject=Liste der mit dem Projekt verbundenen Lagerbewegungen
 ListStockTransferProject=Liste der mit dem Projekt verknüpften Lagertransfers
+NoAmountforStockTransfer=Kein Betrag für Lagertransfers im Gewinn standardmäßig.
 StocksArea=Warenlager – Übersicht
 AllWarehouses=Alle Warenlager
 IncludeEmptyDesiredStock=Schließe auch negative Bestände mit undefinierten gewünschten Beständen ein

--- a/htdocs/langs/de_DE/stocks.lang
+++ b/htdocs/langs/de_DE/stocks.lang
@@ -7,6 +7,7 @@ NewWarehouse=Neues Lager / Lagerstandort
 WarehouseEdit=Warenlager bearbeiten
 MenuNewWarehouse=Neues Warenlager
 WarehouseSource=Ursprungslager
+WarehouseDestination=Ziel-Lager
 WarehouseSourceNotDefined=Keine Lager definiert,
 AddWarehouse=Lager erstellen
 AddOne=Hinzufügen

--- a/htdocs/langs/en_US/stocks.lang
+++ b/htdocs/langs/en_US/stocks.lang
@@ -7,6 +7,7 @@ NewWarehouse=New warehouse / Stock Location
 WarehouseEdit=Modify warehouse
 MenuNewWarehouse=New warehouse
 WarehouseSource=Source warehouse
+WarehouseDestination=Destination warehouse
 WarehouseSourceNotDefined=No warehouse defined,
 AddWarehouse=Create warehouse
 AddOne=Add one

--- a/htdocs/langs/en_US/stocks.lang
+++ b/htdocs/langs/en_US/stocks.lang
@@ -31,6 +31,7 @@ ErrorWarehouseRefRequired=Warehouse reference name is required
 MovementId=Movement ID
 StockMovementForId=Movement ID %d
 ListMouvementStockProject=List of stock movements associated to project
+ListStockTransferProject=List of stock transfers associated to project
 StocksArea=Warehouses area
 AllWarehouses=All warehouses
 IncludeEmptyDesiredStock=Include also negative stock with undefined desired stock

--- a/htdocs/langs/en_US/stocks.lang
+++ b/htdocs/langs/en_US/stocks.lang
@@ -32,6 +32,7 @@ MovementId=Movement ID
 StockMovementForId=Movement ID %d
 ListMouvementStockProject=List of stock movements associated to project
 ListStockTransferProject=List of stock transfers associated to project
+NoAmountforStockTransfer=No amount for stock transfer in profit by default.
 StocksArea=Warehouses area
 AllWarehouses=All warehouses
 IncludeEmptyDesiredStock=Include also negative stock with undefined desired stock

--- a/htdocs/langs/es_ES/stocks.lang
+++ b/htdocs/langs/es_ES/stocks.lang
@@ -31,6 +31,7 @@ ErrorWarehouseRefRequired=El nombre de referencia del almacén es obligatorio
 MovementId=ID movimiento
 StockMovementForId=ID movimiento %d
 ListMouvementStockProject=Listado de movimientos de stock asociados al proyecto
+ListStockTransferProject=Listado de transferencias de stock asociadas al proyecto
 StocksArea=Área almacenes
 AllWarehouses=Todos los almacenes
 IncludeEmptyDesiredStock=Incluir también stock negativo con stock deseado indefinido

--- a/htdocs/langs/es_ES/stocks.lang
+++ b/htdocs/langs/es_ES/stocks.lang
@@ -32,6 +32,7 @@ MovementId=ID movimiento
 StockMovementForId=ID movimiento %d
 ListMouvementStockProject=Listado de movimientos de stock asociados al proyecto
 ListStockTransferProject=Listado de transferencias de stock asociadas al proyecto
+NoAmountforStockTransfer=Sin importe para las transferencias de stock en el beneficio por defecto.
 StocksArea=Área almacenes
 AllWarehouses=Todos los almacenes
 IncludeEmptyDesiredStock=Incluir también stock negativo con stock deseado indefinido

--- a/htdocs/langs/es_ES/stocks.lang
+++ b/htdocs/langs/es_ES/stocks.lang
@@ -7,6 +7,7 @@ NewWarehouse=Nuevo almacén / zona de almacenaje
 WarehouseEdit=Edición almacén
 MenuNewWarehouse=Nuevo almacén
 WarehouseSource=Almacén origen
+WarehouseDestination=Almacén de destino
 WarehouseSourceNotDefined=Sin almacenes definidos,
 AddWarehouse=Crear almacén
 AddOne=Añadir uno

--- a/htdocs/langs/fr_FR/stocks.lang
+++ b/htdocs/langs/fr_FR/stocks.lang
@@ -7,6 +7,7 @@ NewWarehouse=Nouvel entrepôt / emplacement
 WarehouseEdit=Édition entrepôt
 MenuNewWarehouse=Nouvel entrepôt
 WarehouseSource=Entrepôt source
+WarehouseDestination=Entrepôt de destination
 WarehouseSourceNotDefined=Aucun entrepôt défini,
 AddWarehouse=Créer entrepôt
 AddOne=En ajouter un

--- a/htdocs/langs/fr_FR/stocks.lang
+++ b/htdocs/langs/fr_FR/stocks.lang
@@ -31,6 +31,7 @@ ErrorWarehouseRefRequired=Le nom de référence de l'entrepôt est obligatoire
 MovementId=Id du mouvement
 StockMovementForId=ID mouvement %d
 ListMouvementStockProject=Liste des mouvements de stocks associés au projet
+ListStockTransferProject=Liste des transferts de stock associés au projet
 StocksArea=Espace entrepôts
 AllWarehouses=Tous les entrepôts
 IncludeEmptyDesiredStock=Inclure aussi les stocks négatifs quand le stock désiré optimal n'est pas défini

--- a/htdocs/langs/fr_FR/stocks.lang
+++ b/htdocs/langs/fr_FR/stocks.lang
@@ -32,6 +32,7 @@ MovementId=Id du mouvement
 StockMovementForId=ID mouvement %d
 ListMouvementStockProject=Liste des mouvements de stocks associés au projet
 ListStockTransferProject=Liste des transferts de stock associés au projet
+NoAmountforStockTransfer=Aucun montant pour les transferts de stock dans le profit par défaut.
 StocksArea=Espace entrepôts
 AllWarehouses=Tous les entrepôts
 IncludeEmptyDesiredStock=Inclure aussi les stocks négatifs quand le stock désiré optimal n'est pas défini

--- a/htdocs/langs/it_IT/stocks.lang
+++ b/htdocs/langs/it_IT/stocks.lang
@@ -7,6 +7,7 @@ NewWarehouse=Nuovo magazzino / deposito
 WarehouseEdit=Modifica magazzino
 MenuNewWarehouse=Nuovo Magazzino
 WarehouseSource=Magazzino di origine
+WarehouseDestination=Magazzino di destinazione
 WarehouseSourceNotDefined=Non è stato definito alcun magazzino.
 AddWarehouse=Crea magazzino
 AddOne=Aggiungi uno

--- a/htdocs/langs/it_IT/stocks.lang
+++ b/htdocs/langs/it_IT/stocks.lang
@@ -32,6 +32,7 @@ MovementId=ID movimento
 StockMovementForId=ID movimento %d
 ListMouvementStockProject=Elenco dei movimenti delle scorte associati al progetto
 ListStockTransferProject=Elenco dei trasferimenti di stock associati al progetto
+NoAmountforStockTransfer=Nessun importo per i trasferimenti di stock nel profitto per impostazione predefinita.
 StocksArea=Area magazzino e scorte
 AllWarehouses=Tutti i magazzini
 IncludeEmptyDesiredStock=Includere anche lo stock negativo con lo stock desiderato non definito

--- a/htdocs/langs/it_IT/stocks.lang
+++ b/htdocs/langs/it_IT/stocks.lang
@@ -31,6 +31,7 @@ ErrorWarehouseRefRequired=Il nome della referenza di magazzino è obbligatorio
 MovementId=ID movimento
 StockMovementForId=ID movimento %d
 ListMouvementStockProject=Elenco dei movimenti delle scorte associati al progetto
+ListStockTransferProject=Elenco dei trasferimenti di stock associati al progetto
 StocksArea=Area magazzino e scorte
 AllWarehouses=Tutti i magazzini
 IncludeEmptyDesiredStock=Includere anche lo stock negativo con lo stock desiderato non definito

--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -1344,10 +1344,15 @@ foreach ($listofreferent as $key => $value) {
 		print '<table class="noborder centpercent">';
 
 		print '<tr class="liste_titre">';
+		$stocktransfercolstyle = ($key == 'stocktransfer' ? ' style="width: 9%"' : '');
 		// Remove link column
 		print '<td style="width: 24px"></td>';
 		// Ref
-		print '<td'.(($tablename != 'actioncomm' && $tablename != 'projet_task') ? ' style="width: 200px"' : '').'>'.$langs->trans("Ref").'</td>';
+		if ($key == 'stocktransfer') {
+			print '<td'.$stocktransfercolstyle.'>'.$langs->trans("Ref").'</td>';
+		} else {
+			print '<td'.(($tablename != 'actioncomm' && $tablename != 'projet_task') ? ' style="width: 200px"' : '').'>'.$langs->trans("Ref").'</td>';
+		}
 		// Product and qty on stock_movement
 		if ('MouvementStock' == $classname) {
 			print '<td style="width: 200px">'.$langs->trans("Product").'</td>';
@@ -1365,15 +1370,15 @@ foreach ($listofreferent as $key => $value) {
 			print '</td>';
 		}
 		if ($key == 'stocktransfer') {
-			print '<td>'.$langs->trans("WarehouseSource").'</td>';
-			print '<td>'.$langs->trans("WarehouseDestination").'</td>';
-			print '<td class="center">'.$langs->trans("DatePrevueDepart").'</td>';
-			print '<td class="center">'.$langs->trans("DateReelleDepart").'</td>';
-			print '<td class="center">'.$langs->trans("DatePrevueArrivee").'</td>';
-			print '<td class="center">'.$langs->trans("DateReelleArrivee").'</td>';
+			print '<td'.$stocktransfercolstyle.'>'.$langs->trans("WarehouseSource").'</td>';
+			print '<td'.$stocktransfercolstyle.'>'.$langs->trans("WarehouseDestination").'</td>';
+			print '<td class="center"'.$stocktransfercolstyle.'>'.$langs->trans("DatePrevueDepart").'</td>';
+			print '<td class="center"'.$stocktransfercolstyle.'>'.$langs->trans("DateReelleDepart").'</td>';
+			print '<td class="center"'.$stocktransfercolstyle.'>'.$langs->trans("DatePrevueArrivee").'</td>';
+			print '<td class="center"'.$stocktransfercolstyle.'>'.$langs->trans("DateReelleArrivee").'</td>';
 		}
 		// Thirdparty or user
-		print '<td>';
+		print '<td'.($key == 'stocktransfer' ? $stocktransfercolstyle : '').'>';
 		if (in_array($tablename, array('projet_task')) && $key == 'project_task') {
 			print ''; // if $key == 'project_task', we don't want details per user
 		} elseif (in_array($tablename, array('payment_various'))) {
@@ -1411,24 +1416,44 @@ foreach ($listofreferent as $key => $value) {
 		if ($key == 'loan') {
 			print '<td class="right" width="120">'.$langs->trans("LoanCapital").'</td>';
 		} elseif (empty($value['disableamount'])) {
-			print '<td class="right" width="120">'.$langs->trans("AmountHT").'</td>';
+			if ($key == 'stocktransfer') {
+				print '<td class="right"'.$stocktransfercolstyle.'>'.$langs->trans("AmountHT").'</td>';
+			} else {
+				print '<td class="right" width="120">'.$langs->trans("AmountHT").'</td>';
+			}
 		} else {
-			print '<td width="120"></td>';
+			if ($key == 'stocktransfer') {
+				print '<td'.$stocktransfercolstyle.'></td>';
+			} else {
+				print '<td width="120"></td>';
+			}
 		}
 		// Amount TTC
 		//if (empty($value['disableamount']) && ! in_array($tablename, array('projet_task'))) print '<td class="right" width="120">'.$langs->trans("AmountTTC").'</td>';
 		if ($key == 'loan') {
 			print '<td class="right" width="120">'.$langs->trans("RemainderToPay").'</td>';
 		} elseif (empty($value['disableamount'])) {
-			print '<td class="right" width="120">'.$langs->trans("AmountTTC").'</td>';
+			if ($key == 'stocktransfer') {
+				print '<td class="right"'.$stocktransfercolstyle.'>'.$langs->trans("AmountTTC").'</td>';
+			} else {
+				print '<td class="right" width="120">'.$langs->trans("AmountTTC").'</td>';
+			}
 		} else {
-			print '<td width="120"></td>';
+			if ($key == 'stocktransfer') {
+				print '<td'.$stocktransfercolstyle.'></td>';
+			} else {
+				print '<td width="120"></td>';
+			}
 		}
 		// Status
 		if (in_array($tablename, array('projet_task'))) {
 			print '<td class="right" width="200">'.$langs->trans("ProgressDeclared").'</td>';
 		} else {
-			print '<td class="right" width="200">'.$langs->trans("Status").'</td>';
+			if ($key == 'stocktransfer') {
+				print '<td class="right"'.$stocktransfercolstyle.'>'.$langs->trans("Status").'</td>';
+			} else {
+				print '<td class="right" width="200">'.$langs->trans("Status").'</td>';
+			}
 		}
 		print '</tr>';
 

--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -747,7 +747,7 @@ $listofreferent = array(
 		'class' => 'StockTransfer',
 		'table' => 'stocktransfer_stocktransfer',
 		'datefieldname' => 'datem',
-		'margin' => 'minus',
+		'margin' => '',
 		'project_field' => 'fk_project',
 		'disableamount' => 1,
 		'urlnew' => DOL_URL_ROOT.'/product/stock/stocktransfer/stocktransfer_card.php?action=create&projectid='.$id.'&backtopage='.urlencode($_SERVER['PHP_SELF'].'?id='.$id),

--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -1129,7 +1129,7 @@ foreach ($listofreferent as $key => $value) {
 			if ($key == 'intervention' && !$margin) {
 				print '<span class="opacitymedium">'.$form->textwithpicto($langs->trans("NA"), $langs->trans("AmountOfInteventionNotIncludedByDefault")).'</span>';
 			} elseif ($key == 'stocktransfer') {
-				print '<span class="opacitymedium">'.$form->textwithpicto($langs->trans("NA"), $langs->trans("AmountOfInteventionNotIncludedByDefault")).'</span>';
+				print '<span class="opacitymedium">'.$form->textwithpicto($langs->trans("NA"), $langs->trans("NoAmountforStockTransfer")).'</span>';
 			} else {
 				if ($key == 'propal') {
 					print '<span class="opacitymedium">'.$form->textwithpicto('', $langs->trans("SignedOnly")).'</span>';
@@ -1142,7 +1142,7 @@ foreach ($listofreferent as $key => $value) {
 			if ($key == 'intervention' && !$margin) {
 				print '<span class="opacitymedium">'.$form->textwithpicto($langs->trans("NA"), $langs->trans("AmountOfInteventionNotIncludedByDefault")).'</span>';
 			} elseif ($key == 'stocktransfer') {
-				print '<span class="opacitymedium">'.$form->textwithpicto($langs->trans("NA"), $langs->trans("AmountOfInteventionNotIncludedByDefault")).'</span>';
+				print '<span class="opacitymedium">'.$form->textwithpicto($langs->trans("NA"), $langs->trans("NoAmountforStockTransfer")).'</span>';
 			} else {
 				if ($key == 'propal') {
 					print '<span class="opacitymedium">'.$form->textwithpicto('', $langs->trans("SignedOnly")).'</span>';

--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -1128,6 +1128,8 @@ foreach ($listofreferent as $key => $value) {
 			print '<td class="right">';
 			if ($key == 'intervention' && !$margin) {
 				print '<span class="opacitymedium">'.$form->textwithpicto($langs->trans("NA"), $langs->trans("AmountOfInteventionNotIncludedByDefault")).'</span>';
+			} elseif ($key == 'stocktransfer') {
+				print '<span class="opacitymedium">'.$langs->trans("NA").'</span>';
 			} else {
 				if ($key == 'propal') {
 					print '<span class="opacitymedium">'.$form->textwithpicto('', $langs->trans("SignedOnly")).'</span>';
@@ -1139,6 +1141,8 @@ foreach ($listofreferent as $key => $value) {
 			print '<td class="right">';
 			if ($key == 'intervention' && !$margin) {
 				print '<span class="opacitymedium">'.$form->textwithpicto($langs->trans("NA"), $langs->trans("AmountOfInteventionNotIncludedByDefault")).'</span>';
+			} elseif ($key == 'stocktransfer') {
+				print '<span class="opacitymedium">'.$langs->trans("NA").'</span>';
 			} else {
 				if ($key == 'propal') {
 					print '<span class="opacitymedium">'.$form->textwithpicto('', $langs->trans("SignedOnly")).'</span>';

--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -743,7 +743,7 @@ $listofreferent = array(
 	),
 	'stocktransfer' => array(
 		'name' => "StockTransfer",
-		'title' => "ListMouvementStockProject",
+		'title' => "ListStockTransferProject",
 		'class' => 'StockTransfer',
 		'table' => 'stocktransfer_stocktransfer',
 		'datefieldname' => 'datem',

--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -754,7 +754,7 @@ $listofreferent = array(
 		'lang' => 'stocks',
 		'buttonnew' => 'StockTransferNew',
 		'testnew' => $user->hasRight('stocktransfer', 'stocktransfer', 'write'),
-		'test' => isModEnabled('stocktransfer') && $user->hasRight('stocktransfer', 'stocktransfer', 'read') && getDolGlobalString('STOCK_MOVEMENT_INTO_PROJECT_OVERVIEW')
+		'test' => isModEnabled('stocktransfer') && $user->hasRight('stocktransfer', 'stocktransfer', 'read')
 	),
 	'stock_mouvement' => array(
 		'name' => "MouvementStockAssociated",

--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -741,6 +741,21 @@ $listofreferent = array(
 		'testnew' => $user->hasRight('project', 'creer'),
 		'test' => isModEnabled('project') && $user->hasRight('projet', 'lire') && !getDolGlobalString('PROJECT_HIDE_TASKS')
 	),
+	'stocktransfer' => array(
+		'name' => "StockTransfer",
+		'title' => "ListMouvementStockProject",
+		'class' => 'StockTransfer',
+		'table' => 'stocktransfer_stocktransfer',
+		'datefieldname' => 'datem',
+		'margin' => 'minus',
+		'project_field' => 'fk_project',
+		'disableamount' => 0,
+		'urlnew' => DOL_URL_ROOT.'/product/stock/stocktransfer/stocktransfer_card.php?action=create&projectid='.$id.'&backtopage='.urlencode($_SERVER['PHP_SELF'].'?id='.$id),
+		'lang' => 'stocks',
+		'buttonnew' => 'StockTransferNew',
+		'testnew' => $user->hasRight('stocktransfer', 'stocktransfer', 'write'),
+		'test' => isModEnabled('stocktransfer') && $user->hasRight('stocktransfer', 'stocktransfer', 'read') && getDolGlobalString('STOCK_MOVEMENT_INTO_PROJECT_OVERVIEW')
+	),
 	'stock_mouvement' => array(
 		'name' => "MouvementStockAssociated",
 		'title' => "ListMouvementStockProject",
@@ -881,7 +896,7 @@ if (!$showdatefilter) {
 
 $langs->loadLangs(array("suppliers", "bills", "orders", "proposals", "margins"));
 
-if (isModEnabled('stock')) {
+if (isModEnabled('stock') || isModEnabled('stocktransfer')) {
 	$langs->load('stocks');
 }
 

--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -1362,6 +1362,14 @@ foreach ($listofreferent as $key => $value) {
 			print $langs->trans("Date");
 		}
 		print '</td>';
+		if ($key == 'stocktransfer') {
+			print '<td>'.$langs->trans("WarehouseSource").'</td>';
+			print '<td>'.$langs->trans("WarehouseDestination").'</td>';
+			print '<td class="center">'.$langs->trans("DatePrevueDepart").'</td>';
+			print '<td class="center">'.$langs->trans("DateReelleDepart").'</td>';
+			print '<td class="center">'.$langs->trans("DatePrevueArrivee").'</td>';
+			print '<td class="center">'.$langs->trans("DateReelleArrivee").'</td>';
+		}
 		// Thirdparty or user
 		print '<td>';
 		if (in_array($tablename, array('projet_task')) && $key == 'project_task') {
@@ -1641,6 +1649,25 @@ foreach ($listofreferent as $key => $value) {
 					print dol_print_date($date, 'day');
 				}
 				print '</td>';
+
+				if ($key == 'stocktransfer') {
+					$warehouseSource = new Entrepot($db);
+					$warehouseDestination = new Entrepot($db);
+					print '<td class="tdoverflowmax150">';
+					if (!empty($element->fk_warehouse_source) && $warehouseSource->fetch($element->fk_warehouse_source) > 0) {
+						print $warehouseSource->getNomUrl(1);
+					}
+					print '</td>';
+					print '<td class="tdoverflowmax150">';
+					if (!empty($element->fk_warehouse_destination) && $warehouseDestination->fetch($element->fk_warehouse_destination) > 0) {
+						print $warehouseDestination->getNomUrl(1);
+					}
+					print '</td>';
+					print '<td class="center">'.dol_print_date($element->date_prevue_depart, 'day').'</td>';
+					print '<td class="center">'.dol_print_date($element->date_reelle_depart, 'day').'</td>';
+					print '<td class="center">'.dol_print_date($element->date_prevue_arrivee, 'day').'</td>';
+					print '<td class="center">'.dol_print_date($element->date_reelle_arrivee, 'day').'</td>';
+				}
 
 				// Third party or user
 				print '<td class="tdoverflowmax150">';

--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -1129,7 +1129,7 @@ foreach ($listofreferent as $key => $value) {
 			if ($key == 'intervention' && !$margin) {
 				print '<span class="opacitymedium">'.$form->textwithpicto($langs->trans("NA"), $langs->trans("AmountOfInteventionNotIncludedByDefault")).'</span>';
 			} elseif ($key == 'stocktransfer') {
-				print '<span class="opacitymedium">'.$langs->trans("NA").'</span>';
+				print '<span class="opacitymedium">'.$form->textwithpicto($langs->trans("NA"), $langs->trans("AmountOfInteventionNotIncludedByDefault")).'</span>';
 			} else {
 				if ($key == 'propal') {
 					print '<span class="opacitymedium">'.$form->textwithpicto('', $langs->trans("SignedOnly")).'</span>';
@@ -1142,7 +1142,7 @@ foreach ($listofreferent as $key => $value) {
 			if ($key == 'intervention' && !$margin) {
 				print '<span class="opacitymedium">'.$form->textwithpicto($langs->trans("NA"), $langs->trans("AmountOfInteventionNotIncludedByDefault")).'</span>';
 			} elseif ($key == 'stocktransfer') {
-				print '<span class="opacitymedium">'.$langs->trans("NA").'</span>';
+				print '<span class="opacitymedium">'.$form->textwithpicto($langs->trans("NA"), $langs->trans("AmountOfInteventionNotIncludedByDefault")).'</span>';
 			} else {
 				if ($key == 'propal') {
 					print '<span class="opacitymedium">'.$form->textwithpicto('', $langs->trans("SignedOnly")).'</span>';

--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -1354,14 +1354,16 @@ foreach ($listofreferent as $key => $value) {
 			print '<td style="width: 50px">'.$langs->trans("Qty").'</td>';
 		}
 		// Date
-		print '<td'.(($tablename != 'actioncomm' && $tablename != 'projet_task') ? ' style="width: 200px"' : '').' class="center">';
-		if (in_array($tablename, array('projet_task'))) {
-			print $langs->trans("TimeSpent");
+		if ($key != 'stocktransfer') {
+			print '<td'.(($tablename != 'actioncomm' && $tablename != 'projet_task') ? ' style="width: 200px"' : '').' class="center">';
+			if (in_array($tablename, array('projet_task'))) {
+				print $langs->trans("TimeSpent");
+			}
+			if (!in_array($tablename, array('projet_task'))) {
+				print $langs->trans("Date");
+			}
+			print '</td>';
 		}
-		if (!in_array($tablename, array('projet_task'))) {
-			print $langs->trans("Date");
-		}
-		print '</td>';
 		if ($key == 'stocktransfer') {
 			print '<td>'.$langs->trans("WarehouseSource").'</td>';
 			print '<td>'.$langs->trans("WarehouseDestination").'</td>';
@@ -1631,24 +1633,26 @@ foreach ($listofreferent as $key => $value) {
 					$date = $element->datestart;
 				}
 
-				print '<td class="center">';
-				if ($tablename == 'actioncomm') {
-					'@phan-var-force ActionComm $element';
-					print dol_print_date($element->datep, 'dayhour');
-					if ($element->datef && $element->datef > $element->datep) {
-						print " - ".dol_print_date($element->datef, 'dayhour');
+				if ($key != 'stocktransfer') {
+					print '<td class="center">';
+					if ($tablename == 'actioncomm') {
+						'@phan-var-force ActionComm $element';
+						print dol_print_date($element->datep, 'dayhour');
+						if ($element->datef && $element->datef > $element->datep) {
+							print " - ".dol_print_date($element->datef, 'dayhour');
+						}
+					} elseif (in_array($tablename, array('projet_task'))) {
+						'@phan-var-force Task $element';
+						$tmpprojtime = $element->getSumOfAmount($idofelementuser ? $elementuser : '', (string) $dates, (string) $datee); // $element is a task. $elementuser may be empty
+						print '<a href="'.DOL_URL_ROOT.'/projet/tasks/time.php?id='.$idofelement.'&withproject=1">';
+						print convertSecondToTime($tmpprojtime['nbseconds'], 'allhourmin');
+						print '</a>';
+						$total_time_by_line = $tmpprojtime['nbseconds'];
+					} else {
+						print dol_print_date($date, 'day');
 					}
-				} elseif (in_array($tablename, array('projet_task'))) {
-					'@phan-var-force Task $element';
-					$tmpprojtime = $element->getSumOfAmount($idofelementuser ? $elementuser : '', (string) $dates, (string) $datee); // $element is a task. $elementuser may be empty
-					print '<a href="'.DOL_URL_ROOT.'/projet/tasks/time.php?id='.$idofelement.'&withproject=1">';
-					print convertSecondToTime($tmpprojtime['nbseconds'], 'allhourmin');
-					print '</a>';
-					$total_time_by_line = $tmpprojtime['nbseconds'];
-				} else {
-					print dol_print_date($date, 'day');
+					print '</td>';
 				}
-				print '</td>';
 
 				if ($key == 'stocktransfer') {
 					$warehouseSource = new Entrepot($db);
@@ -1927,6 +1931,9 @@ foreach ($listofreferent as $key => $value) {
 				if (in_array($tablename, array('projet_task'))) {
 					$colspan = 2;
 				}
+				if ($key == 'stocktransfer') {
+					$colspan = 9;
+				}
 
 				print '<tr class="liste_total"><td colspan="'.$colspan.'">'.$langs->trans("Number").': '.$i.'</td>';
 				if (in_array($tablename, array('projet_task'))) {
@@ -1977,6 +1984,9 @@ foreach ($listofreferent as $key => $value) {
 				$colspan = 7;
 				if ($tablename == 'fichinter') {
 					$colspan++;
+				}
+				if ($key == 'stocktransfer') {
+					$colspan = 12;
 				}
 				print '<tr><td colspan="'.$colspan.'"><span class="opacitymedium">'.$langs->trans("None").'</td></tr>';
 			}

--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -749,7 +749,7 @@ $listofreferent = array(
 		'datefieldname' => 'datem',
 		'margin' => 'minus',
 		'project_field' => 'fk_project',
-		'disableamount' => 0,
+		'disableamount' => 1,
 		'urlnew' => DOL_URL_ROOT.'/product/stock/stocktransfer/stocktransfer_card.php?action=create&projectid='.$id.'&backtopage='.urlencode($_SERVER['PHP_SELF'].'?id='.$id),
 		'lang' => 'stocks',
 		'buttonnew' => 'StockTransferNew',


### PR DESCRIPTION
### Motivation
- Expose stock movement records from the `stocktransfer` module in the project overview and allow creating project-linked stock transfers, and ensure stock language strings are available when `stocktransfer` is enabled.

### Description
- Add a `stocktransfer` entry to the `$listofreferent` array with keys for `name`, `title`, `class`, `table`, `datefieldname`, `project_field`, `urlnew`, `lang`, `buttonnew`, and permission checks using `isModEnabled('stocktransfer')` and `hasRight` calls.
- Update the language loading condition from `isModEnabled('stock')` to `isModEnabled('stock') || isModEnabled('stocktransfer')` so `stocks` language file is loaded when the `stocktransfer` module is enabled.
- Use the creation URL `product/stock/stocktransfer/stocktransfer_card.php?action=create&projectid=...` and wire tests for read/write rights on the `stocktransfer` module.