### PR TITLE
Use correct mail model `stocktransfer_send` for presend

### DIFF
--- a/htdocs/admin/mails_templates.php
+++ b/htdocs/admin/mails_templates.php
@@ -242,9 +242,6 @@ if (isModEnabled("shipping")) {
 	$elementList['shipping_send'] = img_picto('', 'dolly', 'class="pictofixedwidth"').dol_escape_htmltag($langs->trans('MailToSendShipment'));
 	$elementList['delivery_send'] = img_picto('', 'dolly', 'class="pictofixedwidth"').dol_escape_htmltag($langs->trans('MailToSendDelivery'));
 }
-if (isModEnabled('stocktransfer')) {
-	$elementList['stocktransfer_send'] = img_picto('', 'dolly', 'class="pictofixedwidth"').dol_escape_htmltag($langs->trans('MailToSendStockTransfer'));
-}
 if (isModEnabled("reception")) {
 	$elementList['reception_send'] = img_picto('', 'dollyrevert', 'class="pictofixedwidth"').dol_escape_htmltag($langs->trans('MailToSendReception'));
 }
@@ -283,6 +280,9 @@ if (isModEnabled('partnership') && $user->hasRight('partnership', 'read')) {
 }
 if (isModEnabled('product') && $user->hasRight('produit', 'lire')) {
 	$elementList['product_send'] = img_picto('', 'product', 'class="pictofixedwidth"').dol_escape_htmltag($langs->trans('Product'));
+}
+if (isModEnabled('stocktransfer')) {
+	$elementList['stocktransfer_send'] = img_picto('', 'fa-box-open', 'class="pictofixedwidth"').dol_escape_htmltag($langs->trans('MailToSendStockTransfer'));
 }
 
 $parameters = array('elementList' => $elementList);

--- a/htdocs/admin/mails_templates.php
+++ b/htdocs/admin/mails_templates.php
@@ -282,7 +282,7 @@ if (isModEnabled('product') && $user->hasRight('produit', 'lire')) {
 	$elementList['product_send'] = img_picto('', 'product', 'class="pictofixedwidth"').dol_escape_htmltag($langs->trans('Product'));
 }
 if (isModEnabled('stocktransfer')) {
-	$elementList['stocktransfer_send'] = img_picto('', 'fa-box-open', 'class="pictofixedwidth"').dol_escape_htmltag($langs->trans('MailToSendStockTransfer'));
+	$elementList['stocktransfer_send'] = '<span class="fas fa-box-open em080 valignmiddle pictomodule paddingrightonly" style="color: #a69944;"></span>'.dol_escape_htmltag($langs->trans('MailToSendStockTransfer'));
 }
 
 $parameters = array('elementList' => $elementList);

--- a/htdocs/admin/mails_templates.php
+++ b/htdocs/admin/mails_templates.php
@@ -242,7 +242,7 @@ if (isModEnabled("shipping")) {
 	$elementList['shipping_send'] = img_picto('', 'dolly', 'class="pictofixedwidth"').dol_escape_htmltag($langs->trans('MailToSendShipment'));
 	$elementList['delivery_send'] = img_picto('', 'dolly', 'class="pictofixedwidth"').dol_escape_htmltag($langs->trans('MailToSendDelivery'));
 }
-if (isModEnabled('stocktransfer') && $user->hasRight('stocktransfer', 'stocktransfer', 'read')) {
+if (isModEnabled('stocktransfer')) {
 	$elementList['stocktransfer_send'] = img_picto('', 'dolly', 'class="pictofixedwidth"').dol_escape_htmltag($langs->trans('MailToSendStockTransfer'));
 }
 if (isModEnabled("reception")) {

--- a/htdocs/admin/mails_templates.php
+++ b/htdocs/admin/mails_templates.php
@@ -242,6 +242,9 @@ if (isModEnabled("shipping")) {
 	$elementList['shipping_send'] = img_picto('', 'dolly', 'class="pictofixedwidth"').dol_escape_htmltag($langs->trans('MailToSendShipment'));
 	$elementList['delivery_send'] = img_picto('', 'dolly', 'class="pictofixedwidth"').dol_escape_htmltag($langs->trans('MailToSendDelivery'));
 }
+if (isModEnabled('stocktransfer') && $user->hasRight('stocktransfer', 'stocktransfer', 'read')) {
+	$elementList['stocktransfer_send'] = img_picto('', 'dolly', 'class="pictofixedwidth"').dol_escape_htmltag($langs->trans('MailToSendStockTransfer'));
+}
 if (isModEnabled("reception")) {
 	$elementList['reception_send'] = img_picto('', 'dollyrevert', 'class="pictofixedwidth"').dol_escape_htmltag($langs->trans('MailToSendReception'));
 }

--- a/htdocs/langs/de_DE/admin.lang
+++ b/htdocs/langs/de_DE/admin.lang
@@ -2127,6 +2127,7 @@ MailToSendOrder=Kundenaufträge
 MailToSendInvoice=Kundenrechnungen
 MailToSendShipment=Lieferungen
 MailToSendDelivery=Lieferungen
+MailToSendStockTransfer=Lagertransfers
 MailToSendIntervention=Serviceaufträge
 MailToSendSupplierRequestForQuotation=Offertanfrage
 MailToSendSupplierOrder=Lieferantenbestellungen

--- a/htdocs/langs/en_US/admin.lang
+++ b/htdocs/langs/en_US/admin.lang
@@ -2130,6 +2130,7 @@ MailToSendOrder=Sales orders
 MailToSendInvoice=Customer invoices
 MailToSendShipment=Shipments
 MailToSendDelivery=Deliveries
+MailToSendStockTransfer=Stock transfers
 MailToSendIntervention=Interventions
 MailToSendSupplierRequestForQuotation=Quotation request
 MailToSendSupplierOrder=Purchase orders

--- a/htdocs/langs/en_US/agenda.lang
+++ b/htdocs/langs/en_US/agenda.lang
@@ -217,14 +217,11 @@ BookCalSystem=Online booking
 BookCalInitHelp=To start, go into menu to create a new Calendar with availabilities...
 PublicLinkForBooking=Public link for booking
 
-ADDSTOCKInDolibarr=Stock transfer %s : Destination stock increase done.
-CLOSEInDolibarr=Stock transfer %s completed.
-DESTOCKInDolibarr=Stock transfer %s : Source stock decrease done.
-ADDSTOCK_CANCELInDolibarr=Stock transfer %s : Destination stock increase canceled.
-DESTOCK_CANCELInDolibarr=Stock transfer %s : Source stock decrease canceled.
-VALIDATEInDolibarr=Stock transfer %s validated.
-UNVALIDATEInDolibarr=Stock transfer %s set back to draft.
-MODIFYInDolibarr=Stock transfer %s modified.
-
+STOCKTRANSFER_ADDSTOCKInDolibarr=Stock transfer %s : Destination stock increase done.
+STOCKTRANSFER_CLOSEInDolibarr=Stock transfer %s completed.
+STOCKTRANSFER_DESTOCKInDolibarr=Stock transfer %s : Source stock decrease done.
 STOCKTRANSFER_ADDSTOCK_CANCELInDolibarr=Stock transfer %s : Destination stock increase canceled.
 STOCKTRANSFER_DESTOCK_CANCELInDolibarr=Stock transfer %s : Source stock decrease canceled.
+STOCKTRANSFER_VALIDATEInDolibarr=Stock transfer %s validated.
+STOCKTRANSFER_UNVALIDATEInDolibarr=Stock transfer %s set back to draft.
+STOCKTRANSFER_MODIFYInDolibarr=Stock transfer %s modified.

--- a/htdocs/langs/es_ES/admin.lang
+++ b/htdocs/langs/es_ES/admin.lang
@@ -2127,6 +2127,7 @@ MailToSendOrder=Pedidos
 MailToSendInvoice=Facturas a clientes
 MailToSendShipment=Envíos
 MailToSendDelivery=Envíos
+MailToSendStockTransfer=Transferencias de stock
 MailToSendIntervention=Intervenciones
 MailToSendSupplierRequestForQuotation=Para enviar solicitud de presupuesto de proveedor
 MailToSendSupplierOrder=Pedidos a proveedor

--- a/htdocs/langs/fr_FR/admin.lang
+++ b/htdocs/langs/fr_FR/admin.lang
@@ -2128,6 +2128,7 @@ MailToSendOrder=Commandes clients
 MailToSendInvoice=Factures clients
 MailToSendShipment=Expéditions
 MailToSendDelivery=Livraisons
+MailToSendStockTransfer=Transferts de stock
 MailToSendIntervention=Interventions
 MailToSendSupplierRequestForQuotation=Demande de devis
 MailToSendSupplierOrder=Commandes fournisseurs

--- a/htdocs/langs/it_IT/admin.lang
+++ b/htdocs/langs/it_IT/admin.lang
@@ -2127,6 +2127,7 @@ MailToSendOrder=Ordini Cliente
 MailToSendInvoice=Fatture attive
 MailToSendShipment=Spedizioni
 MailToSendDelivery=Consegne
+MailToSendStockTransfer=Trasferimenti di magazzino
 MailToSendIntervention=Interventi
 MailToSendSupplierRequestForQuotation=Richiesta di preventivo
 MailToSendSupplierOrder=Ordini d'acquisto

--- a/htdocs/product/stock/stocktransfer/stocktransfer_card.php
+++ b/htdocs/product/stock/stocktransfer/stocktransfer_card.php
@@ -1159,7 +1159,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 	}
 
 	// Presend form
-	$modelmail = 'stocktransfer';
+	$modelmail = 'stocktransfer_send';
 	$defaulttopic = 'InformationMessage';
 	$diroutput = $conf->stocktransfer->dir_output;
 	$trackid = 'stocktransfer'.$object->id;

--- a/htdocs/product/stock/stocktransfer/stocktransfer_card.php
+++ b/htdocs/product/stock/stocktransfer/stocktransfer_card.php
@@ -1161,7 +1161,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 	// Presend form
 	$modelmail = 'stocktransfer_send';
 	$defaulttopic = 'InformationMessage';
-	$diroutput = $conf->stocktransfer->dir_output;
+	$diroutput = $conf->stocktransfer->dir_output.'/'.$object->element;
 	$trackid = 'stocktransfer'.$object->id;
 
 	include DOL_DOCUMENT_ROOT.'/core/tpl/card_presend.tpl.php';


### PR DESCRIPTION
### Motivation
- Ensure the presend email form uses the intended mail template for stock transfers by selecting the correct model name.

### Description
- Updated the mail model used in the presend step by changing ` $modelmail` value from `'stocktransfer'` to `'stocktransfer_send'` in `htdocs/product/stock/stocktransfer/stocktransfer_card.php`.