### PR TITLE
fix(webportal): restore contract menu closure in menu.tpl.php

### DIFF
--- a/htdocs/public/webportal/tpl/menu.tpl.php
+++ b/htdocs/public/webportal/tpl/menu.tpl.php
@@ -70,6 +70,8 @@ if ($context->userIsLog()) {
 			'url' => $context->getControllerUrl('contractlist'),
 			'name' => $langs->trans('WebPortalContractListMenu'),
 			'group' => 'administrative' // group identifier for the group if necessary
+		);
+	}
 	// menu interventions
 	if (isModEnabled('intervention') && getDolGlobalInt('WEBPORTAL_FICHEINTER_LIST_ACCESS')) {
 		$navMenu['ficheinter_list'] = array(


### PR DESCRIPTION
### Motivation
- Corriger un bloc malformé dans le template `htdocs/public/webportal/tpl/menu.tpl.php` où la fermeture du tableau et du bloc conditionnel pour le menu « contract » manquait, causant des erreurs d'annotation/indentation.

### Description
- Rétablit les fermetures manquantes `);` et `}` du tableau `$navMenu['contract_list']` dans `htdocs/public/webportal/tpl/menu.tpl.php` pour restaurer une structure PHP valide et conserver l'indentation par tabulations.

### Testing
- Vérification syntaxique réalisée avec `php -l htdocs/public/webportal/tpl/menu.tpl.php` qui a renvoyé « No syntax errors detected ».

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3d7be2690832ebfe35eba9906a417)