### PR TITLE
QUAL: fix Phan notices in document controller, customreports and bankjournal

### DIFF
--- a/htdocs/accountancy/journal/bankjournal.php
+++ b/htdocs/accountancy/journal/bankjournal.php
@@ -936,7 +936,7 @@ if (!$error && $action == 'writebookkeeping' && $user->hasRight('accounting', 'b
 							$bookkeeping->subledger_label = $tabcompany[$key]['name'];
 							if (empty($conf->cache['accountingaccountincurrententity'][$tabpay[$key]["account_various"]])) {
 								$accountingaccount = new AccountingAccount($db);
-								$accountingaccount->fetch(null, $tabpay[$key]["account_various"], true);
+								$accountingaccount->fetch(0, $tabpay[$key]["account_various"], true);
 								$conf->cache['accountingaccountincurrententity'][$tabpay[$key]["account_various"]] = $accountingaccount;
 							} else {
 								$accountingaccount = $conf->cache['accountingaccountincurrententity'][$tabpay[$key]["account_various"]];

--- a/htdocs/core/customreports.php
+++ b/htdocs/core/customreports.php
@@ -67,27 +67,33 @@ if (!defined('USE_CUSTOM_REPORT_AS_INCLUDE')) {
 	$tabfamily  = GETPOST('tabfamily', 'aZ09');
 
 	$search_measures = GETPOST('search_measures', 'array:alphanohtml');
+	if (!is_array($search_measures)) {
+		$search_measures = array();
+	}
 
-	//$search_xaxis = GETPOST('search_xaxis', 'array');
+	$search_xaxis = array();
 	if (GETPOST('search_xaxis', 'alpha') && GETPOST('search_xaxis', 'alpha') != '-1') {
 		$search_xaxis = array(GETPOST('search_xaxis', 'alpha'));
 	}
-	//$search_groupby = GETPOST('search_groupby', 'array');
+	$search_groupby = array();
 	if (GETPOST('search_groupby', 'alpha') && GETPOST('search_groupby', 'alpha') != '-1') {
 		$search_groupby = array(GETPOST('search_groupby', 'alpha'));
 	}
 	'@phan-var-force string[] $search_groupby';
 
 	$search_yaxis = GETPOST('search_yaxis', 'array:alphanohtml');
+	if (!is_array($search_yaxis)) {
+		$search_yaxis = array();
+	}
 	$search_graph = (string) GETPOST('search_graph', 'restricthtml');
 
-	$search_measures = array_map(function ($value) {
+	$search_measures = array_map(function (string $value): string {
 		return preg_replace('/[^a-z0-9\._\-]+/', '', $value); }, $search_measures);
-	$search_xaxis = array_map(function ($value) {
+	$search_xaxis = array_map(function (string $value): string {
 		return preg_replace('/[^a-z0-9\._\-]+/', '', $value); }, $search_xaxis);
-	$search_yaxis = array_map(function ($value) {
+	$search_yaxis = array_map(function (string $value): string {
 		return preg_replace('/[^a-z0-9\._\-]+/', '', $value); }, $search_yaxis);
-	$search_groupby = array_map(function ($value) {
+	$search_groupby = array_map(function (string $value): string {
 		return preg_replace('/[^a-z0-9\._\-]+/', '', $value); }, $search_groupby);
 
 	// Load variable for pagination

--- a/htdocs/webportal/controllers/document.controller.class.php
+++ b/htdocs/webportal/controllers/document.controller.class.php
@@ -207,7 +207,7 @@ class DocumentController extends Controller
 								$tmpuser = new User($this->db);
 								$tmpuser->socid = $socId;
 
-								include_once DOl_DOCUMENT_ROOT.'/core/lib/security.lib.php';
+								include_once DOL_DOCUMENT_ROOT.'/core/lib/security.lib.php';
 
 								$ok = checkUserAccessToObject($tmpuser, array($obj->src_object_type), $obj->src_object_id, '', '', 'fk_soc');
 
@@ -236,7 +236,6 @@ class DocumentController extends Controller
 
 		$fullpath_original_file = $pathdir . '/' . $original_file; // $fullpath_original_file is now a full path name
 
-		var_dump($pathdir);
 		// Security:
 		// We refuse directory transversal change and pipes in file names
 		if (preg_match('/\.\./', $fullpath_original_file) || preg_match('/[<>|]/', $fullpath_original_file)) {


### PR DESCRIPTION
### Motivation
- Corriger des alertes de l’analyse statique (Phan) et supprimer un debug resté en place pour assurer la compatibilité avec PHP 8 et propreté du code.

### Description
- Corrigé la constante mal orthographiée dans le contrôleur webportal (`DOl_DOCUMENT_ROOT` -> `DOL_DOCUMENT_ROOT`).
- Supprimé le `var_dump($pathdir)` laissé dans le flux de téléchargement de documents.
- Fiabilisé le parsing des paramètres dans `htdocs/core/customreports.php` en initialisant les tableaux optionnels et en ajoutant des types explicites (`string`) et type de retour pour les closures utilisées par `array_map()` afin de lever les avertissements de typage.
- Évitée la passe d’un `null` à `AccountingAccount::fetch()` en remplaçant l’argument `null` par `0` dans le journal bancaire.

### Testing
- Exécuté `php -l htdocs/webportal/controllers/document.controller.class.php && php -l htdocs/core/customreports.php && php -l htdocs/accountancy/journal/bankjournal.php` et obtenu « No syntax errors detected » pour les trois fichiers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c44e9b8bc8832e9fe3fae8d7fe3f8b)