### PR TITLE
QUAL: fix PHPStan warnings on project tasks mass actions

### DIFF
--- a/htdocs/projet/class/task.class.php
+++ b/htdocs/projet/class/task.class.php
@@ -625,7 +625,7 @@ class Task extends CommonObjectLine
 	 * Return authorized tasks for selected ids.
 	 *
 	 * @param	User	$user		Current user
-	 * @param	array	$toselect	List of selected task ids
+	 * @param	array<int>	$toselect	List of selected task ids
 	 * @return	array<int,object>	Tasks indexed by task id
 	 */
 	public function getAuthorizedTasksForMassAction($user, $toselect)

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -325,7 +325,7 @@ if (empty($reshook)) {
 					}
 					$task->progress = max(0, min(100, (int) $progressraw));
 					$task->status = ($task->progress >= 100 ? Task::STATUS_CLOSED : Task::STATUS_ONGOING);
-				} elseif ($effectiveMassAction == 'update_selected_tasks_start_date' || $effectiveMassAction == 'update_selected_tasks_deadline') {
+				} elseif (in_array($effectiveMassAction, array('update_selected_tasks_start_date', 'update_selected_tasks_deadline'), true)) {
 					$taskdatetime = GETPOST('task_datetime_'.$taskId, 'alphanohtml');
 					$tasktimestamp = 0;
 					if (!empty($taskdatetime)) {

--- a/htdocs/projet/tasks/list.php
+++ b/htdocs/projet/tasks/list.php
@@ -324,7 +324,7 @@ if (empty($reshook)) {
 					}
 					$task->progress = max(0, min(100, (int) $progressraw));
 					$task->status = ($task->progress >= 100 ? Task::STATUS_CLOSED : Task::STATUS_ONGOING);
-				} elseif ($effectiveMassAction == 'update_selected_tasks_start_date' || $effectiveMassAction == 'update_selected_tasks_deadline') {
+				} elseif (in_array($effectiveMassAction, array('update_selected_tasks_start_date', 'update_selected_tasks_deadline'), true)) {
 					$taskdatetime = GETPOST('task_datetime_'.$taskId, 'alphanohtml');
 					dol_syslog(__FILE__." datetime payload taskId=".$taskId." value='".$taskdatetime."' keep_duration=".GETPOSTINT('keep_duration_'.$taskId), LOG_WARNING);
 					$tasktimestamp = 0;


### PR DESCRIPTION
### Motivation
- Corriger des avertissements PHPStan relatifs aux actions de masse des tâches projet causés par des comparaisons lâches toujours vraies et un typage d'itérable manquant.

### Description
- Remplacement des conditions lâches par `in_array($effectiveMassAction, array('update_selected_tasks_start_date', 'update_selected_tasks_deadline'), true)` dans `htdocs/projet/tasks/list.php` et `htdocs/projet/tasks.php`.
- Ajout de la précision de type `@param array<int> $toselect` pour la méthode `Task::getAuthorizedTasksForMassAction()` dans `htdocs/projet/class/task.class.php`.
- Modifications comportementales nulles, visant uniquement à améliorer la qualité de l'analyse statique et la lisibilité.

### Testing
- Vérification de syntaxe PHP via `php -l` sur `htdocs/projet/tasks/list.php`, `htdocs/projet/tasks.php` et `htdocs/projet/class/task.class.php` — réussite.
- Exécution de `vendor/bin/phpstan analyse` impossible car `vendor/bin/phpstan` est absent dans l'environnement de build.
- Exécution globale `phpstan analyse` impossible car la commande `phpstan` n'est pas installée dans l'environnement de build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c460001a9c832e9c2f8ca074485709)