### PR TITLE
QUAL: Corrige alertes Phan dans document, massactions, customreports et bankjournal

### DIFF
--- a/htdocs/accountancy/journal/bankjournal.php
+++ b/htdocs/accountancy/journal/bankjournal.php
@@ -936,7 +936,7 @@ if (!$error && $action == 'writebookkeeping' && $user->hasRight('accounting', 'b
 							$bookkeeping->subledger_label = $tabcompany[$key]['name'];
 							if (empty($conf->cache['accountingaccountincurrententity'][$tabpay[$key]["account_various"]])) {
 								$accountingaccount = new AccountingAccount($db);
-								$accountingaccount->fetch(null, $tabpay[$key]["account_various"], true);
+								$accountingaccount->fetch(0, $tabpay[$key]["account_various"], true);
 								$conf->cache['accountingaccountincurrententity'][$tabpay[$key]["account_various"]] = $accountingaccount;
 							} else {
 								$accountingaccount = $conf->cache['accountingaccountincurrententity'][$tabpay[$key]["account_various"]];

--- a/htdocs/core/customreports.php
+++ b/htdocs/core/customreports.php
@@ -67,6 +67,8 @@ if (!defined('USE_CUSTOM_REPORT_AS_INCLUDE')) {
 	$tabfamily  = GETPOST('tabfamily', 'aZ09');
 
 	$search_measures = GETPOST('search_measures', 'array:alphanohtml');
+	$search_xaxis = array();
+	$search_groupby = array();
 
 	//$search_xaxis = GETPOST('search_xaxis', 'array');
 	if (GETPOST('search_xaxis', 'alpha') && GETPOST('search_xaxis', 'alpha') != '-1') {
@@ -81,13 +83,13 @@ if (!defined('USE_CUSTOM_REPORT_AS_INCLUDE')) {
 	$search_yaxis = GETPOST('search_yaxis', 'array:alphanohtml');
 	$search_graph = (string) GETPOST('search_graph', 'restricthtml');
 
-	$search_measures = array_map(function ($value) {
+	$search_measures = array_map(function (string $value): string {
 		return preg_replace('/[^a-z0-9\._\-]+/', '', $value); }, $search_measures);
-	$search_xaxis = array_map(function ($value) {
+	$search_xaxis = array_map(function (string $value): string {
 		return preg_replace('/[^a-z0-9\._\-]+/', '', $value); }, $search_xaxis);
-	$search_yaxis = array_map(function ($value) {
+	$search_yaxis = array_map(function (string $value): string {
 		return preg_replace('/[^a-z0-9\._\-]+/', '', $value); }, $search_yaxis);
-	$search_groupby = array_map(function ($value) {
+	$search_groupby = array_map(function (string $value): string {
 		return preg_replace('/[^a-z0-9\._\-]+/', '', $value); }, $search_groupby);
 
 	// Load variable for pagination

--- a/htdocs/core/tpl/massactions_pre.tpl.php
+++ b/htdocs/core/tpl/massactions_pre.tpl.php
@@ -62,10 +62,13 @@
 @phan-var-force string $string
 @phan-var-force CommonObject $objecttmp
 @phan-var-force CommonObject $object
+@phan-var-force string $massaction
+@phan-var-force int[] $arrayofselected
 @phan-var-force int[] $toselect
 @phan-var-force ?string $uploaddir
 @phan-var-force int<0,1> $withmaindocfilemail
 @phan-var-force string $sendto
+@phan-var-force string $search_all
 ';
 
 if (!empty($sall) || !empty($search_all)) {

--- a/htdocs/webportal/controllers/document.controller.class.php
+++ b/htdocs/webportal/controllers/document.controller.class.php
@@ -207,7 +207,7 @@ class DocumentController extends Controller
 								$tmpuser = new User($this->db);
 								$tmpuser->socid = $socId;
 
-								include_once DOl_DOCUMENT_ROOT.'/core/lib/security.lib.php';
+								require_once DOL_DOCUMENT_ROOT.'/core/lib/security.lib.php';
 
 								$ok = checkUserAccessToObject($tmpuser, array($obj->src_object_type), $obj->src_object_id, '', '', 'fk_soc');
 


### PR DESCRIPTION
### Motivation
- Corriger des alertes de l'analyseur statique (Phan) et une faute de constante qui pouvaient conduire à des erreurs sous PHP 8 et dégrader la qualité du code.
- Appliquer des corrections ciblées de typage et de déclarations pour supprimer des faux positifs CI sans modifier le comportement applicatif.

### Description
- `QUAL`: Corrige la constante mal orthographiée et sécurise l'inclusion dans le contrôleur webportal en remplaçant `include_once DOl_DOCUMENT_ROOT` par `require_once DOL_DOCUMENT_ROOT` dans `htdocs/webportal/controllers/document.controller.class.php`.
- Ajout des annotations `@phan-var-force` manquantes pour les variables globales utilisées dans le template `htdocs/core/tpl/massactions_pre.tpl.php` (`$massaction`, `$arrayofselected`, `$search_all`) afin d'éviter des alertes de variables globales non déclarées.
- Initialise les tableaux optionnels et ajoute des types aux closures dans `htdocs/core/customreports.php` en ajoutant ` $search_xaxis = array(); $search_groupby = array();` et en typant les fonctions anonymes en `function (string $value): string` pour satisfaire Phan.
- Remplace l'appel `fetch(null, ...)` par `fetch(0, ...)` dans `htdocs/accountancy/journal/bankjournal.php` pour fournir un argument entier conforme à la signature attendue.
- Ces changements sont limités à des corrections de qualité/typage et n'ont pas vocation à modifier le comportement métier.

### Testing
- Vérification de syntaxe PHP avec `php -l htdocs/webportal/controllers/document.controller.class.php` : succès.
- Vérification de syntaxe PHP avec `php -l htdocs/core/tpl/massactions_pre.tpl.php` : succès.
- Vérification de syntaxe PHP avec `php -l htdocs/core/customreports.php` : succès.
- Vérification de syntaxe PHP avec `php -l htdocs/accountancy/journal/bankjournal.php` : succès.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c463e200ec832e8a9222fd9fa4aef8)