### PR TITLE
QUAL: Fix static analysis notices on tasks/massactions and document controller

### DIFF
--- a/htdocs/core/tpl/massactions_pre.tpl.php
+++ b/htdocs/core/tpl/massactions_pre.tpl.php
@@ -71,6 +71,16 @@
 @phan-var-force string $search_all
 ';
 
+if (!isset($taskstatic) || !is_object($taskstatic)) {
+	$taskstatic = null;
+}
+if (!isset($trackid)) {
+	$trackid = '';
+}
+if (!isset($modelmail)) {
+	$modelmail = '';
+}
+
 if (!empty($sall) || !empty($search_all)) {
 	$search_all = empty($sall) ? $search_all : $sall;
 

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -56,6 +56,8 @@ $langs->loadLangs($langsLoad);
 
 $action = GETPOST('action', 'aZ09');
 $massaction = GETPOST('massaction', 'alpha');
+$massactionbutton = '';
+$permissiontodelete = false;
 //$show_files = GETPOSTINT('show_files');
 $confirm = GETPOST('confirm', 'alpha');
 $cancel = GETPOST('cancel');

--- a/htdocs/webportal/controllers/document.controller.class.php
+++ b/htdocs/webportal/controllers/document.controller.class.php
@@ -236,7 +236,7 @@ class DocumentController extends Controller
 
 		$fullpath_original_file = $pathdir . '/' . $original_file; // $fullpath_original_file is now a full path name
 
-		var_dump($pathdir);
+		// var_dump($pathdir);
 		// Security:
 		// We refuse directory transversal change and pipes in file names
 		if (preg_match('/\.\./', $fullpath_original_file) || preg_match('/[<>|]/', $fullpath_original_file)) {


### PR DESCRIPTION
### Motivation
- Éliminer un appel de debug laissé (`var_dump`) et supprimer des alertes d'analyse statique (Phan) liées à des variables globales optionnelles non initialisées lors du rendu des massactions et de la liste de tâches.

### Description
- Neutralisation de `var_dump($pathdir)` dans `htdocs/webportal/controllers/document.controller.class.php` pour satisfaire la règle `NoVarDumpPlugin`.
- Initialisation de `$massactionbutton` et `$permissiontodelete` dans `htdocs/projet/tasks.php` pour éviter les `PhanPossiblyUndeclaredGlobalVariable` et les mismatchs de nullabilité.
- Ajout de valeurs par défaut pour `$taskstatic`, `$trackid` et `$modelmail` dans `htdocs/core/tpl/massactions_pre.tpl.php` afin d'éviter les `PhanUndeclaredGlobalVariable` quand le template est inclus sans ces variables.

### Testing
- Vérification syntaxique PHP exécutée sur les fichiers modifiés via `php -l`, tous les fichiers renvoient "No syntax errors detected": `htdocs/webportal/controllers/document.controller.class.php` (OK), `htdocs/projet/tasks.php` (OK), `htdocs/core/tpl/massactions_pre.tpl.php` (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c466628430832e88a2bde9623891b8)