### PR TITLE
QUAL: corrige avertissements Phan (nullable / variables non déclarées) dans massactions tâches

### DIFF
--- a/htdocs/core/tpl/massactions_pre.tpl.php
+++ b/htdocs/core/tpl/massactions_pre.tpl.php
@@ -71,15 +71,11 @@
 @phan-var-force string $search_all
 ';
 
-if (!isset($taskstatic) || !is_object($taskstatic)) {
+if (!is_object($taskstatic ?? null)) {
 	$taskstatic = null;
 }
-if (!isset($trackid)) {
-	$trackid = '';
-}
-if (!isset($modelmail)) {
-	$modelmail = '';
-}
+$trackid = (string) ($trackid ?? '');
+$modelmail = (string) ($modelmail ?? '');
 
 if (!empty($sall) || !empty($search_all)) {
 	$search_all = empty($sall) ? $search_all : $sall;

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -1065,7 +1065,7 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 	$linktotasks .= dolGetButtonTitle($langs->trans('ViewGantt'), '', 'fa fa-stream imgforviewmode', DOL_URL_ROOT.'/projet/ganttview.php?id='.$object->id.'&withproject=1', '', 1, array('morecss' => 'reposition marginleftonly'));
 
 	//print_barre_liste($title, 0, $_SERVER["PHP_SELF"], '', $sortfield, $sortorder, $linktotasks, $num, $totalnboflines, 'generic', 0, '', '', 0, 1);
-	print load_fiche_titre($title, $linktotasks.' &nbsp; '.$linktocreatetask, 'projecttask', 0, '', '', $massactionbutton);
+	print load_fiche_titre($title, $linktotasks.' &nbsp; '.$linktocreatetask, 'projecttask', 0, '', '', (string) ($massactionbutton ?? ''));
 
 	$objecttmp = new Task($db);
 	$trackid = 'task'.$taskstatic->id;


### PR DESCRIPTION
### Motivation
- Corriger plusieurs alertes de l'analyseur statique Phan liées à des arguments nullable ou des variables potentiellement non déclarées dans le flux de mass actions des tâches (`htdocs/projet/tasks.php` et `htdocs/core/tpl/massactions_pre.tpl.php`).

### Description
- Dans `htdocs/projet/tasks.php` (autour de `L1068`) on force l'argument 7 passé à `load_fiche_titre()` à être une `string` non-nullable via cast/coalescence: ``(string) ($massactionbutton ?? '')``. 
- Dans `htdocs/core/tpl/massactions_pre.tpl.php` on remplace le `isset()` ambigu par une vérification d'objet robuste pour `$taskstatic` : ``if (!is_object($taskstatic ?? null)) { $taskstatic = null; }``. 
- Dans le même template on initialise explicitement `$trackid` et `$modelmail` en `string` via ``$trackid = (string) ($trackid ?? '');`` et ``$modelmail = (string) ($modelmail ?? '');`` pour éviter les variables non déclarées et assurer la compatibilité de type.
- Les changements sont de nature strictement sûre-typage / initialisation et n'altèrent pas le comportement fonctionnel attendu.

### Testing
- Vérification de syntaxe PHP exécutée avec `php -l htdocs/projet/tasks.php` et `php -l htdocs/core/tpl/massactions_pre.tpl.php`, les deux commandes ont retourné "No syntax errors detected".

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c46f3c24a8832e910f9dbd818a448f)