### PR TITLE
QUAL: remove duplicate permissions key in ci-on-push workflow

### DIFF
--- a/.github/workflows/ci-on-push.yml
+++ b/.github/workflows/ci-on-push.yml
@@ -4,9 +4,6 @@ on: [push]
 permissions:
   contents: read
 
-permissions:
-  contents: read
-
 jobs:
   pre-commit:
     uses: ./.github/workflows/pre-commit.yml


### PR DESCRIPTION
### Motivation
- Corriger l'erreur YAML `key-duplicates` en supprimant la clé `permissions` dupliquée dans le workflow CI pour que la validation YAML / les hooks pré-commit ne remontent plus d'erreur.

### Description
- Supprimé le second bloc top-level `permissions` dans `.github/workflows/ci-on-push.yml`, ne conservant qu'une seule définition `permissions: contents: read`.

### Testing
- Exécution locale de `pre-commit run --files .github/workflows/ci-on-push.yml` a échoué initialement car `pre-commit` n'était pas installé, et après installation via `python3 -m pip install --user pre-commit` l'exécution de `~/.local/bin/pre-commit run --files .github/workflows/ci-on-push.yml` a échoué lors de l'initialisation des hooks en raison d'une erreur réseau (`URLError ... 403 Forbidden`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4e8d3bae4832eb722bf554477caf1)