### PR TITLE
Allow adding and editing free lines on shipments and improve free-line loading

### DIFF
--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -152,6 +152,8 @@ $permissiondellink = $user->hasRight('expedition', 'delivery', 'creer'); // Used
 $permissiontoadd = $user->hasRight('expedition', 'creer');
 $permissiontoedit = $usercancreate; // Used by the include of actions_lineupdown.inc.php
 $permissiontoeditextra = $permissiontoadd;
+$shipmentfromordercanaddproduct = (getDolGlobalString('SHIPMENT_FROM_ORDER_CAN_ADD_PRODUCT') && !empty($object->origin_type) && $object->origin_type == 'commande' && $object->origin_id > 0);
+$shipmentallowfreelines = ((!$origin && getDolGlobalString('SHIPMENT_STANDALONE')) || $shipmentfromordercanaddproduct);
 if (GETPOST('attribute', 'aZ09') && isset($extrafields->attributes[$object->table_element]['perms'][GETPOST('attribute', 'aZ09')])) {
 	// For action 'update_extras', is there a specific permission set for the attribute to update
 	$permissiontoeditextra = dol_eval((string) $extrafields->attributes[$object->table_element]['perms'][GETPOST('attribute', 'aZ09')]);
@@ -849,7 +851,15 @@ if (empty($reshook)) {
 			setEventMessages($line->error, $line->errors, 'errors');
 		}
 	} elseif ($action == 'updateline' && $permissiontoadd && GETPOST('save')) {
-		if (!$origin && getDolGlobalString('SHIPMENT_STANDALONE')) {
+		$isfreeactionline = false;
+		if ($shipmentallowfreelines) {
+			$shipline = new ExpeditionLigne($db);
+			if ($shipline->fetch(GETPOSTINT('lineid')) > 0) {
+				$isfreeactionline = (empty($shipline->fk_elementdet) || $shipline->element_type == 'shipping');
+			}
+		}
+
+		if ($isfreeactionline) {
 			// Update a line
 			// Clean parameters
 
@@ -859,12 +869,12 @@ if (empty($reshook)) {
 			$object->fetch_thirdparty();
 
 			$qty = GETPOST('qty', 'alpha');
-			$description = '';
+			$description = $shipline->description;
 			$fk_parent = 0;
 			$element_type = 'shipping';
-			$fk_unit = '';
-			$fk_product = 0;
-			$rang = 0;
+			$fk_unit = $shipline->fk_unit;
+			$fk_product = (int) $shipline->fk_product;
+			$rang = $shipline->rang;
 
 			// Extrafields
 			$extralabelsline = $extrafields->fetch_name_optionals_label($object->table_element_line);
@@ -876,10 +886,6 @@ if (empty($reshook)) {
 					unset($_POST["options_" . $key]);
 				}
 			}
-
-			$shipline = new ExpeditionLigne($db);
-			$shipline->fetch(GETPOSTINT('lineid'));
-
 
 			if (!$error) {
 				$result = $object->updatelinefree(GETPOSTINT('lineid'), (float) $qty, $element_type, $fk_product, GETPOSTINT('units'), $rang, $description, $fk_parent, 0, $array_options);
@@ -910,7 +916,7 @@ if (empty($reshook)) {
 					setEventMessages($object->error, $object->errors, 'errors');
 				}
 			}
-		} elseif ($origin && $origin_id > 0) {
+		} elseif ((!empty($origin) && $origin_id > 0) || (!empty($object->origin) && $object->origin_id > 0)) {
 			// Update a line
 			// Clean parameters
 			$qty = 0;
@@ -1150,7 +1156,7 @@ if (empty($reshook)) {
 	} elseif ($action == 'updateline' && $permissiontoadd && GETPOST('cancel', 'alpha') == $langs->trans("Cancel")) {
 		header('Location: ' . $_SERVER['PHP_SELF'] . '?id=' . $object->id); // To redisplay the form being edited
 		exit();
-	} elseif ($action == 'addline' && !$origin && getDolGlobalString('SHIPMENT_STANDALONE') && $usercancreate) {	// Add a new line
+	} elseif ($action == 'addline' && $shipmentallowfreelines && $usercancreate) {	// Add a new line
 		$langs->load('errors');
 		$error = 0;
 		$line_desc = (GETPOSTISSET('dp_desc') ? GETPOST('dp_desc', 'restricthtml') : '');
@@ -2617,6 +2623,18 @@ if ($action == 'create' && $usercancreate) {
 	// Edit and view mode
 
 	$lines = $object->lines;
+	$isEditingOriginLine = false;
+	if (!empty($object->origin) && $object->origin_id > 0) {
+		$lines = array_values(array_filter($lines, function ($line) {
+			return !empty($line->origin_line_id);
+		}));
+		foreach ($lines as $line) {
+			if ((int) $line->id == $line_id) {
+				$isEditingOriginLine = true;
+				break;
+			}
+		}
+	}
 
 	$num_prod = count($lines);
 
@@ -3137,7 +3155,7 @@ if ($action == 'create' && $usercancreate) {
 
 	// Lines of products of origin
 	if (!empty($object->origin) && $object->origin_id > 0) {
-		if ($action == 'editline') {
+		if ($action == 'editline' && $isEditingOriginLine) {
 			print '	<form name="updateline" id="updateline" action="' . $_SERVER["PHP_SELF"] . '?id=' . $object->id . '&amp;lineid=' . $line_id . '" method="POST">
 			<input type="hidden" name="token" value="' . newToken() . '">
 			<input type="hidden" name="action" value="updateline">
@@ -3699,6 +3717,60 @@ if ($action == 'create' && $usercancreate) {
 		print '</div>';
 
 		$object->fetchObjectLinked($object->id, $object->element);
+	}
+
+	// Lines added directly on shipments created from a customer order
+	if ($shipmentfromordercanaddproduct && !empty($object->table_element_line)) {
+		$originlines = $object->lines;
+		$result = $object->fetch_lines_free(true);
+		$freeLineIds = array();
+		foreach ($object->lines as $freeline) {
+			$freeLineIds[] = (int) $freeline->id;
+		}
+		$num_prod += count($object->lines);
+
+		if ($action != 'editline' || in_array($line_id, $freeLineIds)) {
+			print '	<form name="addproduct" id="addproduct" action="'.$_SERVER["PHP_SELF"].'?id='.$object->id.(($action != 'editline') ? '' : '#line_'.GETPOSTINT('lineid')).'" method="POST">
+			<input type="hidden" name="token" value="' . newToken().'">
+			<input type="hidden" name="action" value="' . (($action != 'editline') ? 'addline' : 'updateline').'">
+			<input type="hidden" name="mode" value="">
+			<input type="hidden" name="page_y" value="">
+			<input type="hidden" name="id" value="' . $object->id.'">
+			';
+
+			if (!empty($conf->use_javascript_ajax) && $object->status == 0) {
+				include DOL_DOCUMENT_ROOT.'/core/tpl/ajaxrow.tpl.php';
+			}
+
+			print '<div class="div-table-responsive-no-min">';
+			if (!empty($object->lines) || ($object->status == $object::STATUS_DRAFT && $permissiontoadd && $action != 'selectlines' && $action != 'editline')) {
+				print '<table id="tablelinesfree" class="noborder noshadow" width="100%">';
+			}
+
+			if (!empty($object->lines)) {
+				$object->printObjectLines($action, $mysoc, null, GETPOSTINT('lineid'), 1, '/expedition/tpl');
+			}
+
+			if ($object->status == Expedition::STATUS_DRAFT && $permissiontoadd && $action != 'selectlines' && $action != 'editline') {
+				$parameters = array();
+				$reshook = $hookmanager->executeHooks('formAddObjectLine', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
+				if ($reshook < 0) {
+					setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
+				}
+				if (empty($reshook)) {
+					$object->formAddObjectLine(1, $mysoc, $soc);
+				}
+			}
+
+			if (!empty($object->lines) || ($object->status == $object::STATUS_DRAFT && $permissiontoadd && $action != 'selectlines' && $action != 'editline')) {
+				print '</table>';
+			}
+			print '</div>';
+
+			print "</form>\n";
+		}
+
+		$object->lines = $originlines;
 	}
 
 	/*

--- a/htdocs/expedition/class/expedition.class.php
+++ b/htdocs/expedition/class/expedition.class.php
@@ -2328,6 +2328,12 @@ class Expedition extends CommonObject
 				$originline = $obj->fk_elementdet;
 			}
 			$this->db->free($resql);
+
+			$result = $this->fetch_lines_free(true, false);
+			if ($result < 0) {
+				return $result;
+			}
+
 			return 1;
 		} else {
 			$this->error = $this->db->error();
@@ -2340,19 +2346,28 @@ class Expedition extends CommonObject
 	/**
 	 *	Load lines of simple shipment
 	 *
+	 *	@param	bool	$onlyfreelines	Only load shipment lines without an origin line
+	 *	@param	bool	$resetlines		Reset current lines before loading
 	 *	@return	int		>0 if OK, Otherwise if KO
 	 */
-	public function fetch_lines_free()
+	public function fetch_lines_free($onlyfreelines = false, $resetlines = true)
 	{
 		// phpcs:enable
 		global $mysoc;
 
-		$this->lines = array();
+		if ($resetlines) {
+			$this->lines = array();
+		}
 
 		$sql = 'SELECT ed.rowid, ed.fk_expedition, ed.fk_entrepot, ed.fk_product, ed.fk_unit, ed.description, ed.fk_elementdet, ed.fk_element, ed.element_type, ed.qty, ed.rang';
+		$sql .= ', p.ref as product_ref, p.label as product_label, p.fk_product_type, p.tobatch as product_tobatch, p.stockable_product';
+		$sql .= ', p.weight, p.weight_units, p.length, p.length_units, p.width, p.width_units, p.height, p.height_units, p.surface, p.surface_units, p.volume, p.volume_units';
 		$sql .= ' FROM '.MAIN_DB_PREFIX.$this->table_element_line.' as ed';
 		$sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'product as p ON (p.rowid = ed.fk_product)';
 		$sql .= ' WHERE ed.fk_expedition = '.((int) $this->id);
+		if ($onlyfreelines) {
+			$sql .= " AND (ed.fk_elementdet IS NULL OR ed.fk_elementdet = 0 OR ed.element_type = 'shipping')";
+		}
 		$sql .= ' ORDER BY ed.rang, ed.rowid';
 
 		dol_syslog(get_class($this)."::fetch_lines_free", LOG_DEBUG);
@@ -2360,6 +2375,7 @@ class Expedition extends CommonObject
 		if ($result) {
 			$num = $this->db->num_rows($result);
 
+			$lineindex = count($this->lines);
 			$i = 0;
 			while ($i < $num) {
 				$objp = $this->db->fetch_object($result);
@@ -2369,20 +2385,56 @@ class Expedition extends CommonObject
 				$line->rowid            = $objp->rowid;
 				$line->id				= $objp->rowid;
 				$line->fk_expedition	= $this->id;
+				$line->element          = $this->element;
 				$line->description      = $objp->description;
+				$line->desc             = $objp->description;
 				$line->qty              = $objp->qty;
+				$line->qty_asked        = $objp->qty;
 				$line->fk_entrepot      = $objp->fk_entrepot;
 				$line->fk_product       = $objp->fk_product;
+				$line->product_type     = $objp->fk_product_type;
+				$line->fk_product_type  = $objp->fk_product_type;
+				$line->ref              = $objp->product_ref;
+				$line->product_ref      = $objp->product_ref;
+				$line->product_label    = $objp->product_label;
+				$line->product_tobatch  = $objp->product_tobatch;
+				$line->stockable_product = $objp->stockable_product;
+				$line->qty_shipped      = $objp->qty;
+				$line->weight           = $objp->weight;
+				$line->weight_units     = $objp->weight_units;
+				$line->length           = $objp->length;
+				$line->length_units     = $objp->length_units;
+				$line->width            = $objp->width;
+				$line->width_units      = $objp->width_units;
+				$line->height           = $objp->height;
+				$line->height_units     = $objp->height_units;
+				$line->surface          = $objp->surface;
+				$line->surface_units    = $objp->surface_units;
+				$line->volume           = $objp->volume;
+				$line->volume_units     = $objp->volume_units;
+				$line->special_code     = 0;
+				$line->subprice         = 0;
+				$line->total_ht         = 0;
+				$line->total_tva        = 0;
+				$line->total_ttc        = 0;
 				$line->rang             = $objp->rang;
 				$line->fk_element 		= $objp->fk_element;
 				$line->fk_unit          = $objp->fk_unit;
 				$line->fk_elementdet 	= $objp->fk_elementdet;
 				$line->fk_element_type 	= $objp->element_type;
+
+				$detail_entrepot = new stdClass();
+				$detail_entrepot->entrepot_id = $objp->fk_entrepot;
+				$detail_entrepot->qty_shipped = $objp->qty;
+				$detail_entrepot->line_id = $objp->rowid;
+				$line->details_entrepot = array($detail_entrepot);
+
 				$line->fetch_optionals();
 
-				$this->lines[$i] = $line;
+				$this->lines[$lineindex] = $line;
 
 				$i++;
+				$lineindex++;
 			}
 
 			$this->db->free($result);
@@ -3137,14 +3189,13 @@ class Expedition extends CommonObject
 
 				// Loop on each product line to add a stock movement
 				// TODO possibilite d'expedier a partir d'une propale ou autre origine
-				$sql = "SELECT cd.fk_product, cd.subprice,";
+				$sql = "SELECT ed.fk_product, cd.subprice,";
 				$sql .= " ed.rowid, ed.qty, ed.fk_entrepot,";
 				$sql .= " edb.rowid as edbrowid, edb.eatby, edb.sellby, edb.batch, edb.qty as edbqty, edb.fk_origin_stock";
-				$sql .= " FROM ".MAIN_DB_PREFIX."commandedet as cd,";
-				$sql .= " ".MAIN_DB_PREFIX."expeditiondet as ed";
+				$sql .= " FROM ".MAIN_DB_PREFIX."expeditiondet as ed";
+				$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."commandedet as cd ON cd.rowid = ed.fk_elementdet";
 				$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."expeditiondet_batch as edb on edb.fk_expeditiondet = ed.rowid";
 				$sql .= " WHERE ed.fk_expedition = ".((int) $this->id);
-				$sql .= " AND cd.rowid = ed.fk_elementdet";
 
 				dol_syslog(get_class($this)."::valid select details", LOG_DEBUG);
 				$resql = $this->db->query($sql);

--- a/htdocs/expedition/class/expeditionligne.class.php
+++ b/htdocs/expedition/class/expeditionligne.class.php
@@ -335,7 +335,7 @@ class ExpeditionLigne extends CommonObjectLine
 	 */
 	public function fetch($rowid)
 	{
-		$sql = 'SELECT ed.rowid, ed.fk_expedition, ed.fk_entrepot, ed.description, ed.fk_unit, ed.fk_elementdet, ed.element_type, ed.qty, ed.rang, ed.extraparams';
+		$sql = 'SELECT ed.rowid, ed.fk_expedition, ed.fk_entrepot, ed.fk_product, ed.description, ed.fk_unit, ed.fk_elementdet, ed.element_type, ed.qty, ed.rang, ed.extraparams';
 		$sql .= ' FROM '.MAIN_DB_PREFIX.$this->table_element.' as ed';
 		$sql .= ' WHERE ed.rowid = '.((int) $rowid);
 		$result = $this->db->query($sql);
@@ -344,6 +344,7 @@ class ExpeditionLigne extends CommonObjectLine
 			$this->id = $objp->rowid;
 			$this->fk_expedition = $objp->fk_expedition;
 			$this->entrepot_id = $objp->fk_entrepot;
+			$this->fk_product = $objp->fk_product;
 			$this->description = $objp->description;
 			$this->fk_unit = $objp->fk_unit;
 			$this->fk_elementdet = $objp->fk_elementdet;

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -3632,8 +3632,10 @@ class Product extends CommonObject
 		$sql .= " FROM ".$this->db->prefix()."commandedet as cd";
 		$sql .= ", ".$this->db->prefix()."commande as c";
 		$sql .= ", ".$this->db->prefix()."societe as s";
+		$sql .= ", ".$this->db->prefix()."product as te";
 		$sql .= " WHERE c.rowid = cd.fk_commande";
 		$sql .= " AND c.fk_soc = s.rowid";
+		$sql .= " AND te.rowid = cd.fk_product";
 		$sql .= " AND c.entity IN (".getEntity($forVirtualStock && getDolGlobalString('STOCK_CALCULATE_VIRTUAL_STOCK_TRANSVERSE_MODE') ? 'stock' : 'commande').")";
 		$sql .= " AND cd.fk_product = ".((int) $this->id);
 		if (empty($user->fk_soc) && !$user->hasRight('societe', 'client', 'voir') && !$forVirtualStock) {	// For external user, restriction is done on filter on fk_soc directly
@@ -3687,6 +3689,7 @@ class Product extends CommonObject
 					$adeduire = 0;
 					$sql = "SELECT SUM(".$this->db->ifsql('f.type=2', '-1', '1')." * fd.qty) as count FROM ".$this->db->prefix()."facturedet as fd ";
 					$sql .= " JOIN ".$this->db->prefix()."facture as f ON fd.fk_facture = f.rowid";
+					$sql .= " JOIN ".$this->db->prefix()."product as te ON te.rowid = fd.fk_product";
 					//$sql .= " JOIN ".$this->db->prefix()."element_element as el ON ((el.fk_target = f.rowid AND el.targettype = 'facture' AND sourcetype = 'commande') OR (el.fk_source = f.rowid AND el.targettype = 'commande' AND sourcetype = 'facture'))";
 					$sql .= " JOIN ".$this->db->prefix()."element_element as el ON el.fk_target = f.rowid AND el.targettype = 'facture' AND sourcetype = 'commande' ";
 					$sql .= " JOIN ".$this->db->prefix()."commande as c ON el.fk_source = c.rowid";
@@ -3697,6 +3700,7 @@ class Product extends CommonObject
 
 					$sql .= "SELECT SUM(".$this->db->ifsql('f.type=2', '-1', '1')." * fd.qty) as count FROM ".$this->db->prefix()."facturedet as fd ";
 					$sql .= " JOIN ".$this->db->prefix()."facture as f ON fd.fk_facture = f.rowid";
+					$sql .= " JOIN ".$this->db->prefix()."product as te ON te.rowid = fd.fk_product";
 					$sql .= " JOIN ".$this->db->prefix()."element_element as el ON el.fk_source = f.rowid AND el.targettype = 'commande' AND sourcetype = 'facture' ";
 					$sql .= " JOIN ".$this->db->prefix()."commande as c ON el.fk_target = c.rowid";
 					$sql .= " WHERE c.fk_statut IN (".$this->db->sanitize($filtrestatut).") AND c.facture = 0 AND fd.fk_product = ".((int) $this->id);
@@ -3721,6 +3725,7 @@ class Product extends CommonObject
 					$adeduire = 0;
 					$sql = "SELECT sum(".$this->db->ifsql('f.type=2', '-1', '1')." * fd.qty) as count FROM ".$this->db->prefix()."facturedet as fd ";
 					$sql .= " JOIN ".$this->db->prefix()."facture as f ON fd.fk_facture = f.rowid";
+					$sql .= " JOIN ".$this->db->prefix()."product as te ON te.rowid = fd.fk_product";
 					//$sql .= " JOIN ".$this->db->prefix()."element_element as el ON ((el.fk_target = f.rowid AND el.targettype = 'facture' AND sourcetype = 'commande') OR (el.fk_source = f.rowid AND el.targettype = 'commande' AND sourcetype = 'facture'))";
 					$sql .= " JOIN ".$this->db->prefix()."element_element as el ON el.fk_target = f.rowid AND el.targettype = 'facture' AND sourcetype = 'commande' ";
 					$sql .= " JOIN ".$this->db->prefix()."commande as c ON el.fk_source = c.rowid";
@@ -3731,6 +3736,7 @@ class Product extends CommonObject
 
 					$sql .= "SELECT sum(".$this->db->ifsql('f.type=2', '-1', '1')." * fd.qty) as count FROM ".$this->db->prefix()."facturedet as fd ";
 					$sql .= " JOIN ".$this->db->prefix()."facture as f ON fd.fk_facture = f.rowid";
+					$sql .= " JOIN ".$this->db->prefix()."product as te ON te.rowid = fd.fk_product";
 					$sql .= " JOIN ".$this->db->prefix()."element_element as el ON el.fk_source = f.rowid AND el.targettype = 'commande' AND sourcetype = 'facture' ";
 					$sql .= " JOIN ".$this->db->prefix()."commande as c ON el.fk_target = c.rowid";
 					$sql .= " WHERE c.fk_statut IN (".$this->db->sanitize($filtrestatut).") AND f.fk_statut > ".Facture::STATUS_DRAFT." AND fd.fk_product = ".((int) $this->id);


### PR DESCRIPTION
### Motivation
- Enable adding/editing shipment lines that are not tied to an origin order line (free/standalone lines) and allow this for shipments created from orders when configured. 
- Ensure free shipment lines are correctly loaded with product metadata and warehouse details so UI and stock logic can use them. 
- Improve safety of edit flows so only the appropriate lines (origin vs free) can be edited in the right contexts.

### Description
- Add configuration-aware flags (`SHIPMENT_STANDALONE` and new `SHIPMENT_FROM_ORDER_CAN_ADD_PRODUCT`) and compute `shipmentallowfreelines`/`shipmentfromordercanaddproduct` to control whether free lines can be added or edited. 
- Extend `expedition.card.php` to detect and handle free lines for `addline` and `updateline` actions, protect origin lines from inappropriate edits, and render a separate add/edit form for free lines when allowed. 
- Add and enhance `Expedition::fetch_lines_free($onlyfreelines = false, $resetlines = true)` to optionally load only free lines and to populate product and dimension/warehouse metadata and per-entrepot details. 
- Update `Expedition::fetch()` to call `fetch_lines_free()` so free lines are included in the shipment object, and adjust `ExpeditionLigne::fetch()` to read `fk_product` from DB. 
- Populate additional line properties (refs, labels, weights, volumes, product type and stockable flags, qty_shipped, etc.) when loading free lines to match expectations of UI and stock logic. 
- Adjust SQL joins in `Product::load_stats_commande()` queries to include product table references used by hooks/filters.

### Testing
- Performed PHP syntax checks on modified files using `php -l` which reported no syntax errors. 
- Executed the project's PHPUnit test suite with `vendor/bin/phpunit` and observed the suites covering shipping/product logic completed without failures. 
- Ran static analysis/phplint hooks (project CI checks) which returned no regressions on the changed code paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb46956fc8832e9e13f5a048958823)